### PR TITLE
POR-2605 enable timesheets contract view from Contracts page

### DIFF
--- a/src/components/contracts/ContractForm.vue
+++ b/src/components/contracts/ContractForm.vue
@@ -5,7 +5,7 @@
         <v-card>
           <!-- Title -->
           <v-card-title class="d-flex align-center header_style">
-            <v-icon color="white">mdi-file-document-plus</v-icon>
+            <v-icon class="mr-1" color="white">mdi-file-document-plus</v-icon>
             <span class="text-h5">New Contract</span>
           </v-card-title>
           <v-card-text>

--- a/src/components/contracts/ContractsTable.vue
+++ b/src/components/contracts/ContractsTable.vue
@@ -267,7 +267,7 @@
                         variant="text"
                         v-bind="props"
                       >
-                        <v-icon class="case-gray" icon="mdi-cog-outline"></v-icon> </v-btn
+                        <v-icon class="case-gray" icon="mdi-cog"></v-icon> </v-btn
                     ></template>
                     <span>Contract Settings</span>
                   </v-tooltip>

--- a/src/components/contracts/ContractsTable.vue
+++ b/src/components/contracts/ContractsTable.vue
@@ -240,6 +240,7 @@
                             toggleProjectForm = !toggleProjectForm;
                           }
                         "
+                        density="comfortable"
                         icon
                         variant="text"
                         v-bind="props"
@@ -250,6 +251,27 @@
                     <span>Add Project</span>
                   </v-tooltip>
 
+                  <!-- Contract Settings -->
+                  <v-tooltip location="top">
+                    <template v-slot:activator="{ props }">
+                      <v-btn
+                        :disabled="editingItem != null || isEditingProjectItem || contractLoading"
+                        @click.stop="
+                          () => {
+                            toggleContractSettingsModal = true;
+                            clickedContract = item;
+                          }
+                        "
+                        density="comfortable"
+                        icon
+                        variant="text"
+                        v-bind="props"
+                      >
+                        <v-icon class="case-gray" icon="mdi-cog-outline"></v-icon> </v-btn
+                    ></template>
+                    <span>Contract Settings</span>
+                  </v-tooltip>
+
                   <!-- Employees Assigned -->
                   <v-tooltip location="top">
                     <template v-slot:activator="{ props }">
@@ -258,10 +280,11 @@
                         @click.stop="
                           () => {
                             toggleContractEmployeesModal = true;
-                            contractEmployeesAssigned = item;
+                            clickedContract = item;
                           }
                         "
                         icon
+                        density="comfortable"
                         variant="text"
                         v-bind="props"
                       >
@@ -278,6 +301,7 @@
                         variant="text"
                         :disabled="editingItem != null || isEditingProjectItem || contractLoading"
                         v-bind="props"
+                        density="comfortable"
                         @click.stop="clickedEdit(item)"
                       >
                         <v-icon class="case-gray" icon="mdi-pencil" />
@@ -293,10 +317,11 @@
         </v-form>
       </v-container>
     </v-card>
-    <contract-employees-assigned-modal
-      :contract="contractEmployeesAssigned"
-      :toggleModal="toggleContractEmployeesModal"
-    />
+    <contract-employees-assigned-modal :contract="clickedContract" :toggleModal="toggleContractEmployeesModal" />
+    <contract-settings-modal
+      :contract="clickedContract"
+      :toggleModal="toggleContractSettingsModal"
+    ></contract-settings-modal>
     <delete-modal :toggleDeleteModal="toggleContractDeleteModal" :type="'contract'"></delete-modal>
     <contract-project-validate-delete-update-status-modal
       :toggleModal="toggleValidateModal"
@@ -321,6 +346,7 @@ import { getProject } from '@/shared/contractUtils';
 
 import DeleteModal from '../modals/DeleteModal.vue';
 import ContractFilter from './ContractFilter.vue';
+import ContractSettingsModal from '../modals/ContractSettingsModal.vue';
 import ContractProjectValidateDeleteUpdateStatusModal from '../modals/ContractProjectValidateDeleteUpdateStatusModal.vue';
 import ProjectForm from './ProjectForm.vue';
 import GeneralConfirmationModal from '@/components/modals/GeneralConfirmationModal.vue';
@@ -365,6 +391,9 @@ async function created() {
   this.emitter.on('closed-contract-employees-assigned-modal', () => {
     this.toggleContractEmployeesModal = false;
   });
+  this.emitter.on('closed-contract-settings-modal', () => {
+    this.toggleContractSettingsModal = false;
+  });
   this.emitter.on('filter', (filter) => {
     this.filter = filter;
   });
@@ -389,6 +418,7 @@ function beforeUnmount() {
   this.emitter.off('canceled-project-form');
   this.emitter.off('submitted-project-form');
   this.emitter.off('closed-project-employees-assigned-modal');
+  this.emitter.off('closed-contract-settings-modal');
   this.emitter.off('contract-project-validate-error-acknowledged');
   this.emitter.off('filter');
   this.emitter.off('is-editing-project-item');
@@ -910,12 +940,6 @@ function storeContracts() {
 
 // |--------------------------------------------------|
 // |                                                  |
-// |                     WATCHERS                     |
-// |                                                  |
-// |--------------------------------------------------|
-
-// |--------------------------------------------------|
-// |                                                  |
 // |                      EXPORT                      |
 // |                                                  |
 // |--------------------------------------------------|
@@ -926,6 +950,7 @@ export default {
   components: {
     DeleteModal,
     ContractFilter,
+    ContractSettingsModal,
     ContractProjectValidateDeleteUpdateStatusModal,
     GeneralConfirmationModal,
     ProjectForm,
@@ -970,7 +995,7 @@ export default {
       },
       contractStatuses: api.CONTRACT_STATUSES,
       contracts: this.$store.getters.contracts,
-      contractEmployeesAssigned: null,
+      clickedContract: null,
       contractStatusItem: null,
       contractValid: true,
       addProjectUnderContract: null,
@@ -981,6 +1006,7 @@ export default {
       expanded: [],
       toggleContractEmployeesModal: false,
       toggleValidateModal: false,
+      toggleContractSettingsModal: false,
       toggleContractDeleteModal: false,
       toggleContractStatusModal: false,
       contractLoading: false,
@@ -1145,7 +1171,7 @@ td {
 }
 
 .contracts-table :deep(td:nth-child(n + 2):nth-child(-n + 6)) {
-  width: 10%;
+  width: 9%;
 }
 
 .contracts-table :deep(td:nth-of-type(7)) {

--- a/src/components/contracts/ExpandedContractTableRow.vue
+++ b/src/components/contracts/ExpandedContractTableRow.vue
@@ -162,6 +162,7 @@
                         }
                       "
                       icon
+                      density="comfortable"
                       variant="text"
                       v-bind="props"
                     >
@@ -178,6 +179,7 @@
                       :disabled="editingProjectItem != null || isEditingContractItem || projectLoading"
                       icon
                       variant="text"
+                      density="comfortable"
                       @click.stop="clickedEdit(item)"
                       v-bind="props"
                     >

--- a/src/components/employees/form-tabs/ContractTab.vue
+++ b/src/components/employees/form-tabs/ContractTab.vue
@@ -159,17 +159,6 @@
             </v-text-field>
             <!-- End End Date -->
           </v-col>
-          <v-col class="pt-0">
-            <v-switch
-              v-if="(userRoleIsAdmin() || userRoleIsManager()) && show1860Switch(project)"
-              v-model="project.bonusCalculationDate"
-              @click="isolate1860CalcOption(project.projectId)"
-              label="Use for 1860 calculation?"
-              color="primary"
-              class="ma-0 pa-0"
-              hide-details
-            />
-          </v-col>
         </v-row>
       </div>
       <!-- End of project loop -->
@@ -432,34 +421,6 @@ function hasEndDatesFilled(index) {
 } // hasEndDatesFilled
 
 /**
- * Allows admin to select a project as the 1860 calculation without manually
- * unselected the other ones. Also checks to see if the project is current.
- *
- * @param project ID of project to be selected, all others will be unselected
- */
-function isolate1860CalcOption(projectId) {
-  for (let c of this.editedContracts) {
-    for (let p of c.projects) {
-      if (p.projectId !== projectId || p.presentDate !== true) p.bonusCalculationDate = false;
-    }
-  }
-} // isolate1860CalcOption
-
-/**
- * Whether or not to show the 1860 bonus calculation switch. If false, it will also
- * set the bonusCalculationDate to false for the project.
- *
- * @param project project to decide for
- * @return if project should show 1860 calculation
- */
-
-function show1860Switch(project) {
-  let toShow = !project.endDate || isBefore(getTodaysDate(), project.endDate, 'day');
-  if (!toShow) project.bonusCalculationDate = false;
-  return toShow;
-} // show1860Switch
-
-/**
  * Parse the date after losing focus.
  *
  * @return String - The date in YYYY-MM format
@@ -591,8 +552,6 @@ export default {
     getRequiredRules,
     getTodaysDate, // dateUtils
     hasEndDatesFilled,
-    isolate1860CalcOption,
-    show1860Switch,
     isAfter, // dateUtils
     isBefore, // dateUtils
     isEmpty,

--- a/src/components/employees/info-tabs/ContractsTab.vue
+++ b/src/components/employees/info-tabs/ContractsTab.vue
@@ -36,12 +36,6 @@
             <p>
               <v-row>
                 <v-col class="pt-0"> <b>Start Date: </b>{{ monthDayYearFormat(project.startDate) }} </v-col>
-                <v-col class="pt-0">
-                  <span v-if="project.bonusCalculationDate">
-                    <v-tooltip activator="parent" location="right">Used for 1860 calculation</v-tooltip>
-                    <v-icon>mdi-calendar-weekend</v-icon>
-                  </span>
-                </v-col>
               </v-row>
             </p>
             <div v-if="project.endDate">

--- a/src/components/modals/ContractSettingsModal.vue
+++ b/src/components/modals/ContractSettingsModal.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <v-dialog v-model="activate" persistent max-width="650">
+      <v-card>
+        <v-card-title class="d-flex align-center header_style">
+          <v-icon class="mr-1" color="white">mdi-cog-outline</v-icon>
+          <span>Settings for {{ contract.primeName }} {{ contract.contractName }}</span>
+        </v-card-title>
+        <v-card-text>
+          <v-row class="d-flex align-center">
+            <span> Employee Timesheets Contract View: </span>
+            <div>
+              <v-switch
+                v-model="model.contractViewEnabled"
+                color="primary"
+                :label="model.contractViewEnabled ? 'Enabled' : 'Disabled'"
+                class="d-inline-block ml-5"
+                hide-details
+              />
+              <v-tooltip activator="parent" location="top">
+                Displays yearly data based on employee's current project start date
+              </v-tooltip>
+            </div>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            variant="text"
+            @click.native="
+              emit('closed-contract-settings-modal');
+              activate = false;
+            "
+            :disabled="loading"
+            >Close</v-btn
+          >
+          <v-btn
+            variant="text"
+            class="text-green"
+            @click.native="
+              save();
+              activate = false;
+            "
+            :disabled="loading"
+            :loading="loading"
+            >Save</v-btn
+          >
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+<script>
+import _ from 'lodash';
+import api from '@/shared/api.js';
+import { updateStoreContracts } from '@/utils/storeUtils';
+
+// |--------------------------------------------------|
+// |                                                  |
+// |                 LIFECYCLE HOOKS                  |
+// |                                                  |
+// |--------------------------------------------------|
+
+/**
+ * Created lifecyle hook
+ */
+function created() {
+  if (!this.$store.getters.contracts) this.updateStoreContracts();
+} // created
+
+// |--------------------------------------------------|
+// |                                                  |
+// |                     METHODS                      |
+// |                                                  |
+// |--------------------------------------------------|
+
+/**
+ * Emits a message and data if it exists.
+ *
+ * @param msg - Message to emit
+ */
+function emit(msg) {
+  this.emitter.emit(msg);
+} // emit
+
+/**
+ * Save contract settings and dispatch updates to store.
+ */
+async function save() {
+  this.loading = true;
+  let data = { id: this.contract.id, contractViewEnabled: this.model.contractViewEnabled };
+  await api.updateAttribute(api.CONTRACTS, data, 'contractViewEnabled');
+  let contracts = this.$store.getters.contracts;
+  let i = _.findIndex(contracts, (c) => c.id === this.model.id);
+  contracts[i] = _.cloneDeep(this.model);
+  this.$store.dispatch('setContracts', { contracts });
+  this.emit('closed-contract-settings-modal');
+  this.loading = false;
+} // save
+
+// |--------------------------------------------------|
+// |                                                  |
+// |                     WATCHERS                     |
+// |                                                  |
+// |--------------------------------------------------|
+
+/**
+ * Watcher for modal toggle
+ */
+function watchToggleModal() {
+  this.model = _.cloneDeep(this.contract);
+  if (this.toggleModal) this.activate = true;
+} // watchEmployeesAssignedModal
+
+export default {
+  created,
+  data() {
+    return {
+      loading: false,
+      activate: false,
+      model: _.cloneDeep(this.contract)
+    };
+  },
+  methods: {
+    emit,
+    save,
+    updateStoreContracts
+  },
+  props: ['toggleModal', 'contract'],
+  watch: {
+    toggleModal: watchToggleModal
+  }
+};
+</script>

--- a/src/components/shared/ContactEmployeesModal.vue
+++ b/src/components/shared/ContactEmployeesModal.vue
@@ -156,7 +156,7 @@ function customFilter(_, queryText, item) {
  * Copyies the list of employee emails to the user's clipboard.
  */
 async function copyEmailList() {
-  let list = this.getList();
+  let list = getList();
   await navigator.clipboard.writeText(list);
   copied.value = true;
 } // copyEmailList
@@ -165,7 +165,7 @@ async function copyEmailList() {
  * Generate the list of emails and separate by comma for the mail service.
  */
 function emailEmployees() {
-  let list = this.getList();
+  let list = getList();
   window.open(list, '_blank');
 } // emailEmployees
 

--- a/src/components/shared/timesheets/TimeData.vue
+++ b/src/components/shared/timesheets/TimeData.vue
@@ -44,6 +44,7 @@ import api from '@/shared/api';
 import { computed, inject, ref, onBeforeMount, onBeforeUnmount } from 'vue';
 import { useStore } from 'vuex';
 import { difference, isBefore, now } from '@/shared/dateUtils';
+import { updateStoreContracts } from '@/utils/storeUtils';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -340,7 +341,7 @@ async function setData(isCalendarYear, isYearly) {
  * Sets the timesheets data on initial load based on a time period (current and previous pay period displayed).
  */
 async function setInitialData() {
-  await setData();
+  await Promise.all([setData(), !store.getters.contracts ? updateStoreContracts() : _]);
 } // setInitialData
 </script>
 

--- a/src/components/shared/timesheets/TimePeriodHours.vue
+++ b/src/components/shared/timesheets/TimePeriodHours.vue
@@ -158,6 +158,7 @@ import TimePeriodDetails from '@/components/shared/timesheets/TimePeriodDetails.
 import TimePeriodJobCodes from '@/components/shared/timesheets/TimePeriodJobCodes.vue';
 import _ from 'lodash';
 import { computed, inject, ref, watch } from 'vue';
+import { useStore } from 'vuex';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -167,6 +168,7 @@ import { computed, inject, ref, watch } from 'vue';
 
 const props = defineProps(['employee', 'ptoBalances', 'supplementalData', 'timesheets']);
 const emitter = inject('emitter');
+const store = useStore();
 
 const periodIndex = ref(props.timesheets.length - 1);
 const isYearly = ref(false);
@@ -219,7 +221,9 @@ const timeData = computed(() => {
  * @returns Boolean - True if an admin has selected to show a users contract year for a project.
  */
 function showContractYear() {
-  return _.some(props.employee.contracts, (c) => _.find(c.projects, (p) => p.bonusCalculationDate));
+  let empCurContract = _.find(props.employee.contracts, (c) => _.find(c.projects, (p) => !p.endDate));
+  let contract = _.find(store.getters.contracts, (c) => c.id === empCurContract?.contractId);
+  return contract?.contractViewEnabled;
 } // showContractYear
 
 // |--------------------------------------------------|


### PR DESCRIPTION
Ticket Link: [https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2605]
Admins can now enable the Contract Year View button on the timesheets widget for employees by activating the toggle on a Contracts settings modal