### PR TITLE
POR-2440 - change no search result text

### DIFF
--- a/src/views/MyExpenses.vue
+++ b/src/views/MyExpenses.vue
@@ -379,7 +379,7 @@
               item-value="id"
               class="elevation-4 smaller-font"
               density="compact"
-              :no-data-text="`Your search for '${search || ''}' found no results.`"
+              :no-data-text="'No results :('"
               expand-on-click
             >
               <!-- Cost slot -->


### PR DESCRIPTION
Ticket link: <https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2440>
When searching on the My Expenses page, changed the text to say "no results" when there are no results.