### PR TITLE
POR-2619 - Fixed the back button on reports page

### DIFF
--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -125,6 +125,7 @@ import ReportsTechnologies from '@/components/reports/ReportsTechnologies.vue';
 import ReportsSecurityInfo from '../components/reports/ReportsSecurityInfo.vue';
 import { updateStoreEmployees, updateStoreContracts, updateStoreTags } from '@/utils/storeUtils';
 import { isMobile, userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
+import { useRouter } from 'vue-router';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -140,6 +141,7 @@ const wasRedirected = ref(false);
 const requestedDataType = ref(localStorage.getItem('requestedDataType'));
 const store = useStore();
 const emitter = inject('emitter');
+const router = useRouter();
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -180,7 +182,7 @@ onMounted(async () => {
  */
 function backClick() {
   localStorage.setItem('requestedDataType', localStorage.getItem('requestedDataType'));
-  this.$router.push({
+  router.push({
     path: '/stats',
     name: 'stats'
   });


### PR DESCRIPTION
Ticket Link: https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2619

When on stats dash and you clicked on a graph/clearance/employee stats to navigate to a new page, and then clicked on the back button... it wouldn't do anything. Updated the router in the Reports.vue file to allow correct navigation.