### PR TITLE
POR 2591 invalid employee number in url loads page infinitely

### DIFF
--- a/src/views/Employee.vue
+++ b/src/views/Employee.vue
@@ -581,6 +581,7 @@ function refreshKey() {
  * Updates the dropdown employee when the employee model changes.
  */
 function watchModel() {
+  if (!this.model) return;
   this.dropdownEmployee = {
     ..._.cloneDeep(this.model),
     itemTitle: `${this.model.lastName}, ${this.model.nickname || this.model.firstName}`


### PR DESCRIPTION
Ticket link: [POR 2591](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2591)
Fixed the error message that appeared when an invalid employee number was entered in the url (e.g. `/employee/10`), instead of loading infinitely.