### PR TITLE
POR-2336 - Making Job experience graph clickable

### DIFF
--- a/src/components/charts/custom-charts/JobExperiencesChart.vue
+++ b/src/components/charts/custom-charts/JobExperiencesChart.vue
@@ -8,6 +8,7 @@
 import BarChart from '../base-charts/BarChart.vue';
 import { storeIsPopulated } from '@/utils/utils';
 import { difference, getTodaysDate } from '@/shared/dateUtils';
+import _ from 'lodash';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -57,6 +58,8 @@ function findMaxIndex() {
 function jobExperienceData() {
   this.employees = this.$store.getters.employees;
   this.employees.forEach((employee) => {
+    // get the name so we can filter on click later
+    let name = employee.firstName + ' ' + employee.lastName;
     // only include active employees
     if (employee.hireDate !== undefined && employee.workStatus != 0) {
       // find time at case
@@ -79,9 +82,13 @@ function jobExperienceData() {
       let index = Math.floor(Math.round(amOfYears) / 5);
       if (this.jobExperience[index] !== undefined) {
         this.jobExperience[index] += 1; // bumps counter
+        this.jobExperienceNames[index].push(name); // pushed onto the value array
       } else {
         this.jobExperience[index] = 1; // creates array slot
+        this.jobExperienceNames[index] = [name]; // creates a new key-value pair as an array
       }
+      console.log(this.jobExperienceNames);
+      console.log(employee);
     }
   });
 } // jobExperienceData
@@ -146,6 +153,17 @@ function drawJobExpHistGraph() {
         }
       }
     },
+    onClick: (x, y) => {
+      if (_.first(y)) {
+        let index = _.first(y).index;
+        localStorage.setItem('requestedDataType', 'job roles');
+        localStorage.setItem('requestedFilter', this.jobExperienceNames[index]);
+        this.$router.push({
+          path: '/employees',
+          name: 'employees'
+        });
+      }
+    },
     plugins: {
       legend: {
         display: false
@@ -182,7 +200,8 @@ export default {
       chartData: null,
       dataReceived: false,
       employees: null,
-      jobExperience: []
+      jobExperience: [],
+      jobExperienceNames: {}
     };
   },
   methods: {


### PR DESCRIPTION
Ticket link: https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2339

Made the total job experience graph clickable. It will lead to the employees page where it automatically filters by the employees that match the criteria that was clicked on. AKA click on the 5-9 years of experience bar, you will see the employees that have 5-9 years of job experience. 