### PR TITLE
POR 2591 invalid employee number in url loads page infinitely

### DIFF
--- a/src/views/Employee.vue
+++ b/src/views/Employee.vue
@@ -1,10 +1,13 @@
 <template>
   <div v-if="model == null && !loading" class="text-center">
     <h1>Invalid Employee!</h1>
-    <img
-      src="https://media.giphy.com/media/fnuSiwXMTV3zmYDf6k/giphy.gif"
-      alt="GIF of Kazoo Kid saying 'Wait a minute, who are you?'"
-    />
+    <v-container class="invalid-results-gif">
+      <v-img
+        src="https://media.giphy.com/media/fnuSiwXMTV3zmYDf6k/giphy.gif"
+        alt="GIF of Kazoo Kid saying 'Wait a minute, who are you?'"
+        aspect-ratio="4/3"
+      ></v-img>
+    </v-container>
   </div>
   <v-container v-else class="my-3 mx-0 px-0" fluid>
     <v-row v-if="basicEmployeeDataLoading" class="pt-0">
@@ -745,5 +748,11 @@ export default {
   align-items: center !important;
   font-size: 20px !important;
   opacity: 1 !important;
+}
+</style>
+
+<style scoped>
+.invalid-results-gif {
+  max-width: 80%;
 }
 </style>

--- a/src/views/Employee.vue
+++ b/src/views/Employee.vue
@@ -581,6 +581,7 @@ function refreshKey() {
  * Updates the dropdown employee when the employee model changes.
  */
 function watchModel() {
+  if (!this.model) return;
   this.dropdownEmployee = {
     ..._.cloneDeep(this.model),
     itemTitle: `${this.model.lastName}, ${this.model.nickname || this.model.firstName}`


### PR DESCRIPTION
Ticket link: [POR 2591](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2591)
Fixed the error message that appeared when an invalid employee number was entered in the url (e.g. `/employee/10`), instead of loading infinitely.
Also made the gif formatting better for different device sizes.