### PR TITLE
POR 2604 - Restyling download all button on contract page

### DIFF
--- a/src/components/contracts/ConvertContractsToCsv.vue
+++ b/src/components/contracts/ConvertContractsToCsv.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Download CSV Button -->
-  <v-btn class="width" :disabled="midAction" @click="download()" elevation="2" :size="buttonSizing"
+  <v-btn :disabled="midAction" @click="download()" elevation="2" :size="buttonSizing"
     >Download All<icon class="material-icons ml-2" :size="buttonSizing">download</icon></v-btn
   >
 </template>
@@ -45,8 +45,5 @@ export default {
 .download {
   font-size: 20px;
   cursor: pointer;
-}
-.width {
-  width: 21%;
 }
 </style>

--- a/src/components/contracts/ConvertContractsToCsv.vue
+++ b/src/components/contracts/ConvertContractsToCsv.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Download CSV Button -->
-  <v-btn :disabled="midAction" @click="download()" elevation="2" :size="buttonSizing"
-    >Download All<icon class="material-icons ml-2" :size="buttonSizing">download</icon></v-btn
+  <v-btn :disabled="midAction" @click="download()" elevation="2"
+    >Download All<icon class="material-icons ml-2">download</icon></v-btn
   >
 </template>
 <script>
@@ -19,10 +19,6 @@ import contractsCsv from '@/utils/csv/contractsCsv.js';
 function download() {
   contractsCsv.download(this.contracts, this.employees);
 } // download
-
-function buttonSizing(){
-  isMobile || (isSmallScreen && 'x-small') ? 'small' : 'comfortable';
-}
 
 // |--------------------------------------------------|
 // |                                                  |

--- a/src/components/contracts/ConvertContractsToCsv.vue
+++ b/src/components/contracts/ConvertContractsToCsv.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Download CSV Button -->
-  <v-btn :disabled="midAction" @click="download()" elevation="2" :size="isMobile || (isSmallScreen && 'x-small')"
-    ><i class="material-icons">download</i>Download All</v-btn
+  <v-btn class="width" :disabled="midAction" @click="download()" elevation="2" :size="buttonSizing"
+    >Download All<icon class="material-icons ml-2" :size="buttonSizing">download</icon></v-btn
   >
 </template>
 <script>
@@ -19,6 +19,10 @@ import contractsCsv from '@/utils/csv/contractsCsv.js';
 function download() {
   contractsCsv.download(this.contracts, this.employees);
 } // download
+
+function buttonSizing(){
+  isMobile || (isSmallScreen && 'x-small') ? 'small' : 'comfortable';
+}
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -41,5 +45,8 @@ export default {
 .download {
   font-size: 20px;
   cursor: pointer;
+}
+.width {
+  width: 21%;
 }
 </style>

--- a/src/views/Contracts.vue
+++ b/src/views/Contracts.vue
@@ -24,24 +24,23 @@
         <v-btn
           :disabled="!$store.getters.contracts"
           :size="isMobile ? 'small' : 'default'"
-          class="my-2"
+          class="my-2 mr-2"
           @click="toggleContractForm = true"
         >
           Create a contract <v-icon end> mdi-file-document-plus </v-icon>
         </v-btn>
-        <contracts-page-loader v-if="loading" />
-        <contracts-table v-else />
-
-        <br />
-
         <!-- Download contracts CSV button -->
-        <v-card-actions class="justify-end">
+        
           <convert-contracts-to-csv
             :mid-action="midAction"
             :contracts="$store.getters.contracts"
             :employees="$store.getters.employees"
           />
-        </v-card-actions>
+        
+        <contracts-page-loader v-if="loading" />
+        <contracts-table v-else />
+
+        <br />
       </v-container>
     </v-card>
     <ContractForm :toggle-contract-form="toggleContractForm" />

--- a/src/views/Contracts.vue
+++ b/src/views/Contracts.vue
@@ -30,13 +30,13 @@
           Create a contract <v-icon end> mdi-file-document-plus </v-icon>
         </v-btn>
         <!-- Download contracts CSV button -->
-        
-          <convert-contracts-to-csv
-            :mid-action="midAction"
-            :contracts="$store.getters.contracts"
-            :employees="$store.getters.employees"
-          />
-        
+
+        <convert-contracts-to-csv
+          :mid-action="midAction"
+          :contracts="$store.getters.contracts"
+          :employees="$store.getters.employees"
+        />
+
         <contracts-page-loader v-if="loading" />
         <contracts-table v-else />
 


### PR DESCRIPTION
Ticket Link: [POR 2604](https://consultwithcase.atlassian.net/browse/POR-2604)
Restyled the 'download all' button to a similar style to the 'create a contract' button and also moved the 'download all' button next to the 'create a contract button' on the contract page of the portal.