### PR TITLE
POR 1841 dropdown text color to be uniform on mobile

### DIFF
--- a/src/views/Audits.vue
+++ b/src/views/Audits.vue
@@ -12,7 +12,7 @@
         <v-col cols="6" md="3" align-self="center">
           <v-menu>
             <template #activator="{ props }">
-              <v-btn variant="text" color="#bc3825" theme="dark" class="font-weight-bold" v-bind="props">
+              <v-btn variant="text" theme="dark" class="font-weight-bold" v-bind="props">
                 {{ selectedDropdown }}
                 <v-icon>mdi-chevron-down</v-icon>
               </v-btn>

--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -38,7 +38,7 @@
           <div v-if="isMobile()" class="text-center">
             <v-menu offset="y">
               <template #activator="{ props }">
-                <v-btn variant="text" color="#bc3825" theme="dark" class="font-weight-bold" v-bind="props">
+                <v-btn variant="text" theme="dark" class="font-weight-bold" v-bind="props">
                   {{ currentTab.toUpperCase() }} <v-icon class="pb-1"> mdi-chevron-down </v-icon>
                 </v-btn>
               </template>

--- a/src/views/StatsDashboard.vue
+++ b/src/views/StatsDashboard.vue
@@ -11,7 +11,7 @@
         <div v-if="isMobile" class="text-center">
           <v-menu offset="y">
             <template #activator="{ props }">
-              <v-btn variant="text" color="#bc3825" theme="dark" class="font-weight-bold" v-bind="props">
+              <v-btn variant="text" theme="dark" class="font-weight-bold" v-bind="props">
                 {{ statsTab.toUpperCase() }} <v-icon class="pb-1"> mdi-chevron-down </v-icon>
               </v-btn>
             </template>


### PR DESCRIPTION
Ticket Link: [POR 1841](https://consultwithcase.atlassian.net/browse/POR-1841)

Made the dropdown button on the statsdashboard page on mobile the same color as on the profile page.

How to test: Go to mobile view, and go to statsdashboard, reports, and audits and review the color on the dropdown for changing different stats (may have to reload to change to mobile view)