### PR TITLE
POR-2625 - Left text alignment on the Reports page when in mobile view

### DIFF
--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -35,7 +35,7 @@
         <reports-page-loader v-if="loading" />
         <div v-else>
           <!-- user is mobile -->
-          <div v-if="isMobile()" class="text-center">
+          <div v-if="isMobile()" class="text-start">
             <v-menu offset="y">
               <template #activator="{ props }">
                 <v-btn variant="text" color="#bc3825" theme="dark" class="font-weight-bold" v-bind="props">


### PR DESCRIPTION
Ticket link: https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2625

When in mobile view, the data that is shown on the reports page is now aligned on the left instead of in the middle.