### PR TITLE
POR 1927 - Validation and Restriction to badge number field in clearance

### DIFF
--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -122,14 +122,15 @@
           </div>
         </v-col>
         <!-- End Granted Date -->
-
       </v-row>
 
       <!-- Badge Number -->
       <v-text-field
         v-model="clearance.badgeNum"
         prepend-icon="mdi-badge-account-outline"
+        maxlength="5"
         counter="5"
+        :rules="[validateBadge(clearance.badgeNum)]"
         label="Badge Number"
         variant="underlined"
         clearable
@@ -512,6 +513,14 @@ async function validateFields() {
   this.emitter.emit('clearanceStatus', errorCount); // emit error status
 } // validateFields
 
+/**
+ * Validate input field for badge number.
+ */
+function validateBadge(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge Number';
+} //validateBadge
+
 // |--------------------------------------------------|
 // |                                                  |
 // |                     WATCHERS                     |
@@ -609,7 +618,8 @@ export default {
     removeAdjDate,
     removeBiDate,
     removePolyDate,
-    validateFields
+    validateFields,
+    validateBadge
   },
   props: ['model', 'validating'],
   watch: {

--- a/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
+++ b/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
@@ -65,7 +65,9 @@
     <!-- Badge Number -->
     <v-text-field
       v-model="model.badgeNum"
+      maxlength="5"
       counter="5"
+      :rules="[validateBadge(model.badgeNum)]"
       label="Badge Number"
       variant="underlined"
       class="small-field mx-4"
@@ -350,6 +352,14 @@ function removeDate(item, key) {
     return dateConvert !== itemDate;
   });
 } // removeDates
+
+/**
+ * Validate input field for badge number.
+ */
+function validateBadge(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge #';
+} //validateBadge
 </script>
 
 <style scoped>


### PR DESCRIPTION
Ticket Link: [POR 1927](https://consultwithcase.atlassian.net/browse/POR-1927)
Added validation (only numbers and letters) to the badge number field in the clearance form and in the power-edit tab. Also restricted the max number of characters allowed to be inputted to 5.