### PR TITLE
POR 2624 - make time data pto balances mobile friendly

### DIFF
--- a/src/components/shared/timesheets/PTOHours.vue
+++ b/src/components/shared/timesheets/PTOHours.vue
@@ -1,39 +1,45 @@
 <template>
   <div>
-    <div class="d-flex justify-space-between">
-      <h3 class="d-flex align-center">
-        <v-icon class="mr-2">mdi-palm-tree</v-icon>
-        PTO Balances
-        <v-avatar
-          @click="openLink('https://3.basecamp.com/3097063/buckets/179119/messages/6950289713')"
-          class="ml-2 nudge-up pointer"
-          size="x-small"
+    <div class="d-flex flex-wrap justify-start">
+      <div class="mb-2">
+        <h3>
+          <v-icon>mdi-palm-tree</v-icon>
+          PTO Balances
+          <v-avatar
+            @click="openLink('https://3.basecamp.com/3097063/buckets/179119/messages/6950289713')"
+            class="ml-2 mr-2 nudge-up pointer"
+            size="x-small"
+            density="compact"
+          >
+            <v-tooltip activator="parent" location="top">Click for more information</v-tooltip>
+            <v-icon size="x-small" color="#3f51b5">mdi-information</v-icon>
+          </v-avatar>
+        </h3>
+      </div>
+      <div>
+        <v-btn
+          v-if="ptoBalances['PTO'] || ptoBalances['PTO'] === 0"
+          @click="showPTOPlanningFormModal = true"
+          variant="outlined"
           density="compact"
+          class="px-2 mb-2 mr-2 ml-auto"
+          :color="caseRed"
+          width="135"
         >
-          <v-tooltip activator="parent" location="top">Click for more information</v-tooltip>
-          <v-icon size="x-small" color="#3f51b5">mdi-information</v-icon>
-        </v-avatar>
-      </h3>
-      <v-btn
-        v-if="ptoBalances['PTO'] || ptoBalances['PTO'] === 0"
-        @click="showPTOPlanningFormModal = true"
-        variant="outlined"
-        density="compact"
-        class="px-2 mr-2 ml-auto"
-        :color="caseRed"
-      >
-        Plan PTO
-      </v-btn>
-      <v-btn
-        v-if="(ptoBalances['PTO'] || ptoBalances['PTO'] === 0) && system !== 'ADP'"
-        @click="showPTOCashOutFormModal = true"
-        variant="outlined"
-        density="compact"
-        class="px-2"
-        :color="caseRed"
-      >
-        Cash Out PTO
-      </v-btn>
+          Plan PTO
+        </v-btn>
+        <v-btn
+          v-if="(ptoBalances['PTO'] || ptoBalances['PTO'] === 0) && system !== 'ADP'"
+          @click="showPTOCashOutFormModal = true"
+          variant="outlined"
+          density="compact"
+          class="px-2 mb-2"
+          :color="caseRed"
+          width="135"
+        >
+          Cash Out PTO
+        </v-btn>
+      </div>
     </div>
     <div v-if="Object.keys(ptoBalances || []).length === 0" class="my-4">No balances to display</div>
     <div v-for="jobcode in sortedBalancesByDuration" :key="jobcode">

--- a/src/components/shared/timesheets/TimeData.vue
+++ b/src/components/shared/timesheets/TimeData.vue
@@ -1,12 +1,12 @@
 <template>
   <div id="t-sheets-data">
     <v-card density="compact">
-      <v-card-title class="header_style d-flex align-center justify-space-between py-0 relative">
+      <v-card-title class="header_style d-flex align-center justify-space-between py-0 pt-2 relative">
         <h3>{{ system }} Time Data</h3>
         <span v-if="getLastUpdatedText && employeeIsUser()" class="last-updated">
           {{ getLastUpdatedText }}
         </span>
-        <v-btn variant="text" icon="mdi-refresh" @click="resetData()">
+        <v-btn class="pr-xs-1" variant="text" icon="mdi-refresh" @click="resetData()">
           <template v-slot:default>
             <v-tooltip activator="parent" location="top">Refresh {{ system }} data</v-tooltip>
             <v-icon color="white" size="large">mdi-refresh</v-icon>


### PR DESCRIPTION
Ticket link: [POR 2624](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2624)
Gave the refresh button better spacing so it doesn't get cut off.
Made the "Plan PTO" and "Cash out PTO" buttons move to the next line when there's not enough horizontal space.