### PR TITLE
POR 1927 - Adding validation and restricting badge number field in clearance form/power-edit

### DIFF
--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -130,7 +130,7 @@
         prepend-icon="mdi-badge-account-outline"
         maxlength="5"
         counter="5"
-        :rules="[validateBadge(clearance.badgeNum)]"
+        :rules="[getBadgeNumberRules(clearance.badgeNum)]"
         label="Badge Number"
         variant="underlined"
         clearable
@@ -309,7 +309,7 @@
 
 <script>
 import _ from 'lodash';
-import { getDateOptionalRules, getRequiredRules } from '@/shared/validationUtils.js';
+import { getDateOptionalRules, getRequiredRules, getBadgeNumberRules } from '@/shared/validationUtils.js';
 import { asyncForEach, isEmpty } from '@/utils/utils';
 import { format, isAfter, isBefore, DEFAULT_ISOFORMAT, FORMATTED_ISOFORMAT } from '@/shared/dateUtils';
 import { mask } from 'vue-the-mask';
@@ -513,14 +513,6 @@ async function validateFields() {
   this.emitter.emit('clearanceStatus', errorCount); // emit error status
 } // validateFields
 
-/**
- * Validate input field for badge number.
- */
-function validateBadge(badgeNum) {
-  const pattern = /^[A-Za-z0-9_-]*$/;
-  return pattern.test(badgeNum) || 'Invalid Badge Number';
-} //validateBadge
-
 // |--------------------------------------------------|
 // |                                                  |
 // |                     WATCHERS                     |
@@ -619,7 +611,7 @@ export default {
     removeBiDate,
     removePolyDate,
     validateFields,
-    validateBadge
+    getBadgeNumberRules
   },
   props: ['model', 'validating'],
   watch: {

--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -122,14 +122,15 @@
           </div>
         </v-col>
         <!-- End Granted Date -->
-
       </v-row>
 
       <!-- Badge Number -->
       <v-text-field
         v-model="clearance.badgeNum"
         prepend-icon="mdi-badge-account-outline"
+        maxlength="5"
         counter="5"
+        :rules="[validateBadge(clearance.badgeNum)]"
         label="Badge Number"
         variant="underlined"
         clearable
@@ -512,6 +513,14 @@ async function validateFields() {
   this.emitter.emit('clearanceStatus', errorCount); // emit error status
 } // validateFields
 
+/**
+ * Validate input field for badge number.
+ */
+function validateBadge(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge Number';
+} //validateBadge
+
 // |--------------------------------------------------|
 // |                                                  |
 // |                     WATCHERS                     |
@@ -609,7 +618,8 @@ export default {
     removeAdjDate,
     removeBiDate,
     removePolyDate,
-    validateFields
+    validateFields,
+    validateBadge
   },
   props: ['model', 'validating'],
   watch: {

--- a/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
+++ b/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
@@ -67,7 +67,7 @@
       v-model="model.badgeNum"
       maxlength="5"
       counter="5"
-      :rules="[validateBadge(model.badgeNum)]"
+      :rules="[getBadgeNumberRules(model.badgeNum)]"
       label="Badge Number"
       variant="underlined"
       class="small-field mx-4"
@@ -226,6 +226,7 @@ import { inject, ref, watch } from 'vue';
 import { mask } from 'vue-the-mask';
 import { format, isBefore, isValid, DEFAULT_ISOFORMAT, FORMATTED_ISOFORMAT } from '@/shared/dateUtils';
 import {
+  getBadgeNumberRules,
   getAfterSubmissionRules,
   getDateBadgeRules,
   getDateGrantedRules,
@@ -352,14 +353,6 @@ function removeDate(item, key) {
     return dateConvert !== itemDate;
   });
 } // removeDates
-
-/**
- * Validate input field for badge number.
- */
-function validateBadge(badgeNum) {
-  const pattern = /^[A-Za-z0-9_-]*$/;
-  return pattern.test(badgeNum) || 'Invalid Badge #';
-} //validateBadge
 </script>
 
 <style scoped>

--- a/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
+++ b/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
@@ -65,7 +65,9 @@
     <!-- Badge Number -->
     <v-text-field
       v-model="model.badgeNum"
+      maxlength="5"
       counter="5"
+      :rules="[validateBadge(model.badgeNum)]"
       label="Badge Number"
       variant="underlined"
       class="small-field mx-4"
@@ -350,6 +352,14 @@ function removeDate(item, key) {
     return dateConvert !== itemDate;
   });
 } // removeDates
+
+/**
+ * Validate input field for badge number.
+ */
+function validateBadge(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge #';
+} //validateBadge
 </script>
 
 <style scoped>

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -236,6 +236,14 @@ export function getPTOCashOutRules(ptoLimit, employeeId, originalAmount) {
   ];
 } // getPTOCashOutRules
 
+/**
+ * Validate (numbers and letters) input field for badge number.
+ */
+export function getBadgeNumberRules(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge #';
+} //getBadgeNumberRules
+
 export default {
   getDateOptionalRules,
   getDatesArrayOptionalRules,
@@ -257,5 +265,6 @@ export default {
   duplicateEmployeeNumberRule,
   duplicateTechnologyRules,
   technologyExperienceRules,
-  getPTOCashOutRules
+  getPTOCashOutRules,
+  getBadgeNumberRules
 };

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -238,10 +238,12 @@ export function getPTOCashOutRules(ptoLimit, employeeId, originalAmount) {
 
 /**
  * Validate (numbers and letters) input field for badge number.
+ * @param badgeNum employee's badge number
  */
 export function getBadgeNumberRules(badgeNum) {
   const pattern = /^[A-Za-z0-9_-]*$/;
-  return pattern.test(badgeNum) || 'Invalid Badge #';
+  const counter = badgeNum.length == 5;
+  return (pattern.test(badgeNum) && counter) || 'Invalid Badge #';
 } //getBadgeNumberRules
 
 export default {


### PR DESCRIPTION
Ticket Link: [POR 1927](https://consultwithcase.atlassian.net/browse/POR-1927)
Added validation (only numbers and letters allowed) to the badge number field in the Clearance Form and Power-edit. Displays an error message if the inputted badge number does not meet validation or if the badge number is not exactly 5 characters long. Pre-existing badge numbers that are smaller or larger than 5 characters can no longer be saved or edited in power edit until they meet validation requirements (letters/numbers only & 5 characters long).