### PR TITLE
POR- 2655 - migrate deprecated native modifier

### DIFF
--- a/src/components/employees/tags/TagManager.vue
+++ b/src/components/employees/tags/TagManager.vue
@@ -27,7 +27,7 @@
       <v-btn
         color="grey-darken-3"
         variant="text"
-        @click.native="
+        @click="
           emit(`close-tag-manager`);
           activate = false;
         "

--- a/src/components/expenses/ExchangeTrainingDescription.vue
+++ b/src/components/expenses/ExchangeTrainingDescription.vue
@@ -30,14 +30,14 @@
       <!-- Action Button -->
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="grey-darken-3" variant="text" @click.native="emitter.emit('close-exchange-training-desc')">
+        <v-btn color="grey-darken-3" variant="text" @click="emitter.emit('close-exchange-training-desc')">
           Close
         </v-btn>
         <v-btn
           color="green "
           variant="text"
           :disabled="!charMinMet"
-          @click.native="emitter.emit('insert-training-desc', description)"
+          @click="emitter.emit('insert-training-desc', description)"
         >
           Insert Description
         </v-btn>

--- a/src/components/expenses/ExchangeTrainingHoursCalculator.vue
+++ b/src/components/expenses/ExchangeTrainingHoursCalculator.vue
@@ -35,7 +35,7 @@
         <v-btn
           color="grey-darken-3"
           variant="text"
-          @click.native="
+          @click="
             emit('close-exchange-training-hours-calculator');
             activate = false;
           "
@@ -46,7 +46,7 @@
           color="green "
           variant="text"
           :disabled="isNaN(parseInt(salary)) || isNaN(parseFloat(hours))"
-          @click.native="
+          @click="
             emit('insert-training-hours', getCost());
             activate = false;
           "

--- a/src/components/expenses/ExchangeTrainingHoursCalculatorReverse.vue
+++ b/src/components/expenses/ExchangeTrainingHoursCalculatorReverse.vue
@@ -31,7 +31,7 @@
         <v-btn
           color="grey-darken-3"
           variant="text"
-          @click.native="
+          @click="
             emit('close-exchange-training-hours-calculator-reverse');
             activate = false;
           "

--- a/src/components/modals/BudgetSelectModal.vue
+++ b/src/components/modals/BudgetSelectModal.vue
@@ -12,7 +12,7 @@
           <!-- Budget List -->
           <div v-if="budgetYears.length > 0">
             <div v-for="(budgetYear, index) in budgetYears" :key="budgetYear">
-              <v-list-item ripple @click.native="select(budgetYear)" class="pointer">
+              <v-list-item ripple @click="select(budgetYear)" class="pointer">
                 <v-list-item-title>
                   <h2 v-bind:class="{ 'text-center': true, 'text-decoration-underline': isCurrent(budgetYear) }">
                     {{ budgetYear }} - {{ budgetYear + 1 }}
@@ -30,7 +30,7 @@
           <!-- Cancel Button -->
           <v-card-actions>
             <v-spacer></v-spacer>
-            <v-btn color="grey-darken-3" variant="text" @click.native="activate = false"> Close </v-btn>
+            <v-btn color="grey-darken-3" variant="text" @click="activate = false"> Close </v-btn>
           </v-card-actions>
           <!-- End Cancel Button -->
         </v-list>

--- a/src/components/modals/CancelConfirmation.vue
+++ b/src/components/modals/CancelConfirmation.vue
@@ -10,7 +10,7 @@
             id="submitNoBtn"
             color="red"
             variant="text"
-            @click.native="
+            @click="
               activate = false;
               loading = true;
               emit(`backout-canceled-${type}`);
@@ -26,7 +26,7 @@
             id="submitYesBtn"
             color="green-darken-1"
             variant="text"
-            @click.native="
+            @click="
               emit(`backout-confirmed-${type}`);
               activate = false;
               loading = true;

--- a/src/components/modals/ContractEmployeesAssignedModal.vue
+++ b/src/components/modals/ContractEmployeesAssignedModal.vue
@@ -79,7 +79,7 @@
           <v-spacer></v-spacer>
           <v-btn
             variant="text"
-            @click.native="
+            @click="
               emit('closed-contract-employees-assigned-modal');
               activate = false;
             "

--- a/src/components/modals/ContractProjectValidateDeleteUpdateStatusModal.vue
+++ b/src/components/modals/ContractProjectValidateDeleteUpdateStatusModal.vue
@@ -22,7 +22,7 @@
           <v-spacer></v-spacer>
           <v-btn
             variant="text"
-            @click.native="
+            @click="
               activate = false;
               this.emitter.emit('contract-project-validate-error-acknowledged');
             "

--- a/src/components/modals/ContractSettingsModal.vue
+++ b/src/components/modals/ContractSettingsModal.vue
@@ -27,7 +27,7 @@
           <v-spacer></v-spacer>
           <v-btn
             variant="text"
-            @click.native="
+            @click="
               emit('closed-contract-settings-modal');
               activate = false;
             "
@@ -37,7 +37,7 @@
           <v-btn
             variant="text"
             class="text-green"
-            @click.native="
+            @click="
               save();
               activate = false;
             "

--- a/src/components/modals/DeleteErrorModal.vue
+++ b/src/components/modals/DeleteErrorModal.vue
@@ -9,7 +9,7 @@
           <v-btn
             color="gray darken-1"
             variant="text"
-            @click.native="
+            @click="
               emit(`invalid-${type}-delete`);
               activate = false;
             "

--- a/src/components/modals/EEODeclineSelfIdentify.vue
+++ b/src/components/modals/EEODeclineSelfIdentify.vue
@@ -21,7 +21,7 @@
           <v-btn
             color="red"
             variant="text"
-            @click.native="
+            @click="
               emit(`cancel-decline-self-identify`);
               activate = false;
             "
@@ -32,7 +32,7 @@
           <v-btn
             color="green-darken-1"
             variant="text"
-            @click.native="
+            @click="
               emit(`confirm-decline-self-identify`);
               activate = false;
             "

--- a/src/components/modals/FormCancelConfirmation.vue
+++ b/src/components/modals/FormCancelConfirmation.vue
@@ -9,7 +9,7 @@
             id="submitNoBtn"
             color="red"
             variant="text"
-            @click.native="
+            @click="
               emit(`canceled-${type}`);
               activate = false;
             "
@@ -23,7 +23,7 @@
             id="submitYesBtn"
             color="green-darken-1"
             variant="text"
-            @click.native="
+            @click="
               emit(`confirmed-${type}`);
               activate = false;
             "

--- a/src/components/modals/GeneralConfirmationModal.vue
+++ b/src/components/modals/GeneralConfirmationModal.vue
@@ -9,7 +9,7 @@
             id="submitNoBtn"
             color="red"
             variant="text"
-            @click.native="
+            @click="
               emit(`canceled-${type}`);
               activate = false;
             "
@@ -23,7 +23,7 @@
             id="submitYesBtn"
             color="green-darken-1"
             variant="text"
-            @click.native="
+            @click="
               emit(`confirmed-${type}`);
               activate = false;
             "

--- a/src/components/modals/ManyFormErrors.vue
+++ b/src/components/modals/ManyFormErrors.vue
@@ -15,7 +15,7 @@
           <v-spacer></v-spacer>
           <v-btn
             variant="text"
-            @click.native="
+            @click="
               emit('canceled-form');
               activate = false;
             "

--- a/src/components/modals/ProjectsEmployeesAssignedModal.vue
+++ b/src/components/modals/ProjectsEmployeesAssignedModal.vue
@@ -62,7 +62,7 @@
           <v-spacer></v-spacer>
           <v-btn
             variant="text"
-            @click.native="
+            @click="
               emit('closed-project-employees-assigned-modal');
               activate = false;
             "

--- a/src/components/modals/TimeOutModal.vue
+++ b/src/components/modals/TimeOutModal.vue
@@ -9,7 +9,7 @@
           <v-btn
             color="gray darken-1"
             variant="text"
-            @click.native="
+            @click="
               emitter.emit('timeout-acknowledged');
               activate = false;
             "

--- a/src/components/modals/TimeOutWarningModal.vue
+++ b/src/components/modals/TimeOutWarningModal.vue
@@ -6,7 +6,7 @@
         <v-card-text>Warning: Your session will time out in 5 minutes. Please complete any progress.</v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="gray darken-1" variant="text" @click.native="activate = false">Ok</v-btn>
+          <v-btn color="gray darken-1" variant="text" @click="activate = false">Ok</v-btn>
           <v-spacer></v-spacer>
         </v-card-actions>
       </v-card>

--- a/src/components/modals/UnreimburseModal.vue
+++ b/src/components/modals/UnreimburseModal.vue
@@ -11,7 +11,7 @@
           <v-btn
             color="red"
             variant="text"
-            @click.native="
+            @click="
               emit(`canceled-unreimburse-expense`);
               activate = false;
             "
@@ -23,7 +23,7 @@
             color="green-darken-1"
             id="confirmUnreimbursed"
             variant="text"
-            @click.native="
+            @click="
               emit(`confirm-unreimburse-expense`);
               activate = false;
             "

--- a/src/components/reimbursements/UnreimbursedExpensesTable.vue
+++ b/src/components/reimbursements/UnreimbursedExpensesTable.vue
@@ -129,7 +129,7 @@
           <template v-slot:[`item.showOnFeed`]="{ item }">
             <v-switch
               :model-value="item.showSwitch && item.selected"
-              @click.native.stop
+              @click.stop
               @update:model-value="toggleShowOnFeedGroup(item)"
               :disabled="!item.checkBox.all"
               :color="caseGray"

--- a/src/components/shared/ContactEmployeesModal.vue
+++ b/src/components/shared/ContactEmployeesModal.vue
@@ -64,7 +64,7 @@
           color="grey-darken-3"
           variant="text"
           :size="isMobile() ? 'x-small' : 'default'"
-          @click.native="
+          @click="
             emit('close-contact-employees-modal');
             activate = false;
           "


### PR DESCRIPTION
Ticket link: [POR 2655](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2655)
Removed the `.native` modifier from click listeners, following the [migration guide](https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed).