### PR TITLE
POR 1927 - Adding validation and restriction to the badge number field in Clearance

### DIFF
--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -130,7 +130,7 @@
         prepend-icon="mdi-badge-account-outline"
         maxlength="5"
         counter="5"
-        :rules="[validateBadge(clearance.badgeNum)]"
+        :rules="[getBadgeNumberRules(clearance.badgeNum)]"
         label="Badge Number"
         variant="underlined"
         clearable
@@ -309,7 +309,7 @@
 
 <script>
 import _ from 'lodash';
-import { getDateOptionalRules, getRequiredRules } from '@/shared/validationUtils.js';
+import { getDateOptionalRules, getRequiredRules, getBadgeNumberRules } from '@/shared/validationUtils.js';
 import { asyncForEach, isEmpty } from '@/utils/utils';
 import { format, isAfter, isBefore, DEFAULT_ISOFORMAT, FORMATTED_ISOFORMAT } from '@/shared/dateUtils';
 import { mask } from 'vue-the-mask';
@@ -513,14 +513,6 @@ async function validateFields() {
   this.emitter.emit('clearanceStatus', errorCount); // emit error status
 } // validateFields
 
-/**
- * Validate input field for badge number.
- */
-function validateBadge(badgeNum) {
-  const pattern = /^[A-Za-z0-9_-]*$/;
-  return pattern.test(badgeNum) || 'Invalid Badge Number';
-} //validateBadge
-
 // |--------------------------------------------------|
 // |                                                  |
 // |                     WATCHERS                     |
@@ -619,7 +611,7 @@ export default {
     removeBiDate,
     removePolyDate,
     validateFields,
-    validateBadge
+    getBadgeNumberRules
   },
   props: ['model', 'validating'],
   watch: {

--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -510,6 +510,13 @@ async function validateFields() {
   await asyncForEach(components, async (field) => {
     if (field && (await field.validate()).length > 0) errorCount++;
   });
+
+  await this.editedClearances.forEach((clearance) => {
+    //goes through each clearance and ensures it follows validation
+    let badgeValidation = getBadgeNumberRules(clearance);
+    if (badgeValidation(clearance) === 'Invalid Badge #, Must be 5 characters') errorCount++;
+  });
+
   this.emitter.emit('doneValidating', { tab: 'clearance', data: this.editedClearances }); // emit done validating and sends edited data back to parent
   this.emitter.emit('clearanceStatus', errorCount); // emit error status
 } // validateFields

--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -128,12 +128,13 @@
       <v-text-field
         v-model="clearance.badgeNum"
         prepend-icon="mdi-badge-account-outline"
+        clearable
         maxlength="5"
-        counter="5"
-        :rules="[getBadgeNumberRules(clearance.badgeNum)]"
+        counter
+        hide-details="auto"
+        :rules="[getBadgeNumberRules(clearance)]"
         label="Badge Number"
         variant="underlined"
-        clearable
         :disabled="clearance.awaitingClearance"
         @update:focused="capitalizeBadges(clearance)"
       ></v-text-field>

--- a/src/components/employees/form-tabs/ClearanceTab.vue
+++ b/src/components/employees/form-tabs/ClearanceTab.vue
@@ -122,14 +122,15 @@
           </div>
         </v-col>
         <!-- End Granted Date -->
-
       </v-row>
 
       <!-- Badge Number -->
       <v-text-field
         v-model="clearance.badgeNum"
         prepend-icon="mdi-badge-account-outline"
+        maxlength="5"
         counter="5"
+        :rules="[validateBadge(clearance.badgeNum)]"
         label="Badge Number"
         variant="underlined"
         clearable
@@ -512,6 +513,14 @@ async function validateFields() {
   this.emitter.emit('clearanceStatus', errorCount); // emit error status
 } // validateFields
 
+/**
+ * Validate input field for badge number.
+ */
+function validateBadge(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge Number';
+} //validateBadge
+
 // |--------------------------------------------------|
 // |                                                  |
 // |                     WATCHERS                     |
@@ -609,7 +618,8 @@ export default {
     removeAdjDate,
     removeBiDate,
     removePolyDate,
-    validateFields
+    validateFields,
+    validateBadge
   },
   props: ['model', 'validating'],
   watch: {

--- a/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
+++ b/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
@@ -67,7 +67,7 @@
       v-model="model.badgeNum"
       maxlength="5"
       counter="5"
-      :rules="[validateBadge(model.badgeNum)]"
+      :rules="[getBadgeNumberRules(model.badgeNum)]"
       label="Badge Number"
       variant="underlined"
       class="small-field mx-4"
@@ -226,6 +226,7 @@ import { inject, ref, watch } from 'vue';
 import { mask } from 'vue-the-mask';
 import { format, isBefore, isValid, DEFAULT_ISOFORMAT, FORMATTED_ISOFORMAT } from '@/shared/dateUtils';
 import {
+  getBadgeNumberRules,
   getAfterSubmissionRules,
   getDateBadgeRules,
   getDateGrantedRules,
@@ -352,14 +353,6 @@ function removeDate(item, key) {
     return dateConvert !== itemDate;
   });
 } // removeDates
-
-/**
- * Validate input field for badge number.
- */
-function validateBadge(badgeNum) {
-  const pattern = /^[A-Za-z0-9_-]*$/;
-  return pattern.test(badgeNum) || 'Invalid Badge #';
-} //validateBadge
 </script>
 
 <style scoped>

--- a/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
+++ b/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
@@ -65,7 +65,9 @@
     <!-- Badge Number -->
     <v-text-field
       v-model="model.badgeNum"
+      maxlength="5"
       counter="5"
+      :rules="[validateBadge(model.badgeNum)]"
       label="Badge Number"
       variant="underlined"
       class="small-field mx-4"
@@ -350,6 +352,14 @@ function removeDate(item, key) {
     return dateConvert !== itemDate;
   });
 } // removeDates
+
+/**
+ * Validate input field for badge number.
+ */
+function validateBadge(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge #';
+} //validateBadge
 </script>
 
 <style scoped>

--- a/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
+++ b/src/components/employees/power-edit/edit-items/custom-items/Clearances.vue
@@ -66,13 +66,14 @@
     <v-text-field
       v-model="model.badgeNum"
       maxlength="5"
-      counter="5"
-      :rules="[getBadgeNumberRules(model.badgeNum)]"
+      counter
+      hide-details="auto"
+      :rules="[getBadgeNumberRules(model)]"
       label="Badge Number"
       variant="underlined"
       class="small-field mx-4"
       :disabled="model.awaitingClearance"
-      @update:model-value="model.badgeNum = model.badgeNum ? model.badgeNum.toUpperCase() : undefined"
+      @update:focused="model.badgeNum = model.badgeNum ? model.badgeNum.toUpperCase() : undefined"
     ></v-text-field>
     <!-- Badge Expiration Date -->
     <v-text-field

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -243,7 +243,7 @@ export function getBadgeNumberRules(clearance) {
   const pattern = /^[A-Za-z0-9]*$/;
   return (v) =>
     v && clearance.badgeNum
-      ? (pattern.test(clearance.badgeNum) && clearance.badgeNum.length == 5) || 'Invalid Badge #'
+      ? (pattern.test(clearance.badgeNum) && clearance.badgeNum.length == 5) || 'Invalid Badge #, Must be 5 characters'
       : true;
 } //getBadgeNumberRules
 

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -236,6 +236,14 @@ export function getPTOCashOutRules(ptoLimit, employeeId, originalAmount) {
   ];
 } // getPTOCashOutRules
 
+/**
+ * Validate (numbers and letters) input field for badge number.
+ */
+export function getBadgeNumberRules(badgeNum) {
+  const pattern = /^[A-Za-z0-9_-]*$/;
+  return pattern.test(badgeNum) || 'Invalid Badge #';
+} //getBadgeNumberRules
+
 export default {
   getDateOptionalRules,
   getDatesArrayOptionalRules,
@@ -257,5 +265,6 @@ export default {
   duplicateEmployeeNumberRule,
   duplicateTechnologyRules,
   technologyExperienceRules,
-  getPTOCashOutRules
+  getPTOCashOutRules,
+  getBadgeNumberRules
 };

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -238,10 +238,12 @@ export function getPTOCashOutRules(ptoLimit, employeeId, originalAmount) {
 
 /**
  * Validate (numbers and letters) input field for badge number.
+ * @param badgeNum employee's badge number
  */
 export function getBadgeNumberRules(badgeNum) {
   const pattern = /^[A-Za-z0-9_-]*$/;
-  return pattern.test(badgeNum) || 'Invalid Badge #';
+  const counter = badgeNum.length == 5;
+  return (pattern.test(badgeNum) && counter) || 'Invalid Badge #';
 } //getBadgeNumberRules
 
 export default {

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -238,12 +238,13 @@ export function getPTOCashOutRules(ptoLimit, employeeId, originalAmount) {
 
 /**
  * Validate (numbers and letters) input field for badge number.
- * @param badgeNum employee's badge number
  */
-export function getBadgeNumberRules(badgeNum) {
-  const pattern = /^[A-Za-z0-9_-]*$/;
-  const counter = badgeNum.length == 5;
-  return (pattern.test(badgeNum) && counter) || 'Invalid Badge #';
+export function getBadgeNumberRules(clearance) {
+  const pattern = /^[A-Za-z0-9]*$/;
+  return (v) =>
+    v && clearance.badgeNum
+      ? (pattern.test(clearance.badgeNum) && clearance.badgeNum.length == 5) || 'Invalid Badge #'
+      : true;
 } //getBadgeNumberRules
 
 export default {


### PR DESCRIPTION
Ticket Link: [POR 1927](https://consultwithcase.atlassian.net/browse/POR-1927)
Added restriction (has to be 5 or 0 characters) and validation (only letters and numbers) to the badge number field in clearance/power-edit. It should only submit if no badge number is inputted or if a valid 5 character badge number is submitted or else it prevents the user from submitting and gives them a alert.