### PR TITLE
martincc-master-POR-2654 - work days remaining is now from today to end of period date

### DIFF
--- a/src/components/help/TimesheetsCalculationsHelp.vue
+++ b/src/components/help/TimesheetsCalculationsHelp.vue
@@ -65,8 +65,7 @@
         </div>
         <div class="mb-3">
           <div class="font-weight-bold d-inline-block">Work Days Remaining (<span class="var">WDR</span>)</div>
-          = week days from today to the period end date - future days inputted in ADP/QuickBooks - 1 IF today is a week
-          day
+          = week days from today to the period end date - future days inputted in ADP/QuickBooks day
         </div>
       </div>
       <div>Note: You can edit Work Days Remaining field by clicking on it</div>

--- a/src/components/shared/timesheets/TimePeriodDetails.vue
+++ b/src/components/shared/timesheets/TimePeriodDetails.vue
@@ -236,7 +236,6 @@ const remainingHours = computed(() => {
 const remainingWorkDays = computed(() => {
   let remainingDays;
   let daysToSubtract = futureDays.value;
-  if (isWeekDay(today.value)) daysToSubtract += 1;
 
   if (customWorkDayInput.value && Number(customWorkDayInput.value)) {
     remainingDays = customWorkDayInput.value || remainingWorkDays.value;


### PR DESCRIPTION
Ticket link: [https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2654]
The Work Days Remaining field on the Time Data widget no longer subtracts a day if today is a week day.