### PR TITLE
POR 2614 - Tag filtering in a seperate component to be used in multiple components

### DIFF
--- a/src/components/reports/ReportsAwards.vue
+++ b/src/components/reports/ReportsAwards.vue
@@ -231,7 +231,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsAwards.vue
+++ b/src/components/reports/ReportsAwards.vue
@@ -248,7 +248,7 @@ function populateAwardsDropdown() {
       awards.value.push(award.name);
     })
   );
-  awards.value = new Set(awards.value);
+  awards.value = Array.from(new Set(awards.value));
 } // populateAwardsDropdown
 
 /**

--- a/src/components/reports/ReportsAwards.vue
+++ b/src/components/reports/ReportsAwards.vue
@@ -33,34 +33,7 @@
             @click:clear="awardSearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            variant="underlined"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -111,9 +84,10 @@ import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
 const emitter = inject('emitter');
 const store = useStore();
 const router = useRouter();
@@ -148,11 +122,12 @@ const headers = ref([
 const awardSearch = ref(null);
 const awards = ref([]);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable items
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -165,7 +140,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // this one is shown
   populateDropdowns(employeesInfo.value);
   buildAwardsColumns();
@@ -207,16 +181,6 @@ function buildAwardsColumns() {
 } // buildAwardsColumns
 
 /**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
-
-/**
  * handles click event of the employee table entry
  *
  * @param item - the employee
@@ -224,19 +188,6 @@ function chipColor(id) {
 function handleClick(_, { item }) {
   router.push(`/employee/${item.employeeNumber}`);
 } //handleClick
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
 
 /**
  * Populates all awards in the search dropdown.
@@ -275,26 +226,14 @@ function refreshDropdownItems() {
   if (awardSearch.value) {
     searchAwards();
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // remove
 
 /**
  * Filters employees on the data table by the award entered by the user.
@@ -308,24 +247,6 @@ function searchAwards() {
     }
   });
 } // searchAwards
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * Emit new data for this tab
@@ -352,34 +273,6 @@ watch(showInactiveEmployees, () => {
   populateDropdowns(employeesInfo.value);
   refreshDropdownItems();
 }); // watchShowInactiveUsers
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * this watcher will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-}); // watchTagFlip
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
-  refreshDropdownItems();
-}); // watchSelectedTags
 </script>
 
 <style lang="css" scoped>

--- a/src/components/reports/ReportsAwards.vue
+++ b/src/components/reports/ReportsAwards.vue
@@ -33,7 +33,9 @@
             @click:clear="awardSearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -87,6 +89,7 @@ import _ from 'lodash';
 import { employeeFilter } from '@/shared/filterUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 const emitter = inject('emitter');
 const store = useStore();

--- a/src/components/reports/ReportsCertifications.vue
+++ b/src/components/reports/ReportsCertifications.vue
@@ -33,34 +33,7 @@
             @click:clear="certificationSearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            variant="underlined"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -108,13 +81,15 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { getTodaysDate, isSameOrBefore } from '@/shared/dateUtils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
+
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
@@ -125,10 +100,12 @@ const filteredEmployees = ref([]);
 const certificationSearch = ref(null);
 const certifications = ref([]);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
-const tagFlip = ref([]);
-const tags = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
+
 // datatable headers
 const headers = ref([
   {
@@ -160,7 +137,6 @@ const headers = ref([
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
   buildCertificationsColumns();
@@ -204,16 +180,6 @@ function buildCertificationsColumns() {
 } // buildCertificationsColumns
 
 /**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
-
-/**
  * handles click event of the employee table entry
  *
  * @param item - the employee
@@ -221,19 +187,6 @@ function chipColor(id) {
 function handleClick(_, { item }) {
   router.push(`/employee/${item.employeeNumber}`);
 } //handleClick
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
 
 /**
  * Populates all certifications in the search dropdown.
@@ -279,26 +232,14 @@ function refreshDropdownItems() {
   if (certificationSearch.value) {
     searchCertifications();
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // remove
 
 /**
  * Filters employees on the data table by the certification entered by the user.
@@ -312,24 +253,6 @@ function searchCertifications() {
     }
   });
 } // searchCertifications
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * Emit new data for tab.value
@@ -354,34 +277,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsCertifications.vue
+++ b/src/components/reports/ReportsCertifications.vue
@@ -237,7 +237,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsCertifications.vue
+++ b/src/components/reports/ReportsCertifications.vue
@@ -33,7 +33,9 @@
             @click:clear="certificationSearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -88,6 +90,7 @@ import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 
 const store = useStore();

--- a/src/components/reports/ReportsCertifications.vue
+++ b/src/components/reports/ReportsCertifications.vue
@@ -252,7 +252,7 @@ function populateCertificationsDropdown() {
       }
     })
   );
-  certifications.value = new Set(certifications.value);
+  certifications.value = Array.from(new Set(certifications.value));
 } // populateCertificationsDropdown
 
 /**

--- a/src/components/reports/ReportsContracts.vue
+++ b/src/components/reports/ReportsContracts.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-v-model-argument -->
 <template>
   <div>
     <v-container fluid class="px-1 px-md-4">
@@ -47,32 +48,7 @@
           ></v-autocomplete>
         </v-col>
         <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            variant="underlined"
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
@@ -129,6 +105,7 @@
 import _ from 'lodash';
 import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
@@ -136,6 +113,7 @@ import { useRouter } from 'vue-router';
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
+import TagsFilter from '@/components/shared/TagsFilter.vue';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -174,11 +152,12 @@ const noContractPlaceholder = ref(' — No Contract — ');
 const primeSearch = ref(null);
 const primesDropDown = ref([]);
 const search = ref(null); // query text for datatable search fiel)
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable item)
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -191,7 +170,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered list
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
   buildContractsColumn();
@@ -244,16 +222,6 @@ function buildContractsColumn() {
     }
   });
 } // buildContractsColumn
-
-/**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
 
 /**
  * handles click event of the employee table entry
@@ -331,19 +299,6 @@ function populateDropdowns(emps) {
 } // populateDropdowns
 
 /**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
-
-/**
  * Refresh the list based on the current queries
  */
 function refreshDropdownItems() {
@@ -359,26 +314,14 @@ function refreshDropdownItems() {
       return employee.employeeNumber == search.value;
     });
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // removeTag
 
 /**
  * Clears the other search forms and searches the table by contract
@@ -435,24 +378,6 @@ function searchPrimes() {
 } // searchPrimes
 
 /**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
-
-/**
  * Emit new data for tab.value
  *
  * @param event the event data containing the table information
@@ -475,34 +400,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsContracts.vue
+++ b/src/components/reports/ReportsContracts.vue
@@ -102,7 +102,6 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';

--- a/src/components/reports/ReportsContracts.vue
+++ b/src/components/reports/ReportsContracts.vue
@@ -315,7 +315,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsContracts.vue
+++ b/src/components/reports/ReportsContracts.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-v-model-argument -->
 <template>
   <div>
     <v-container fluid class="px-1 px-md-4">

--- a/src/components/reports/ReportsContracts.vue
+++ b/src/components/reports/ReportsContracts.vue
@@ -111,6 +111,7 @@ import { useRouter } from 'vue-router';
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 
 // |--------------------------------------------------|

--- a/src/components/reports/ReportsContracts.vue
+++ b/src/components/reports/ReportsContracts.vue
@@ -315,8 +315,8 @@ function populateContractsAndPrimesDropdown(employees) {
       });
     });
   });
-  contractsDropDown.value = new Set(contractsDropDown.value);
-  primesDropDown.value = new Set(primesDropDown.value);
+  contractsDropDown.value = Array.from(new Set(contractsDropDown.value));
+  primesDropDown.value = Array.from(new Set(primesDropDown.value));
 } // populateContractsAndPrimesDropdown
 
 /**

--- a/src/components/reports/ReportsCustomerOrgs.vue
+++ b/src/components/reports/ReportsCustomerOrgs.vue
@@ -21,7 +21,7 @@
             "
           ></v-autocomplete>
         </v-col>
-        <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-autocomplete
             v-model="custOrgSearch"
             :items="custOrgs"
@@ -33,34 +33,7 @@
             @click:clear="custOrgSearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            variant="underlined"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:model-value="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -120,6 +93,8 @@ import { getActive, getFullName, populateEmployeesDropdown } from './reports-uti
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
@@ -157,11 +132,12 @@ const headers = ref([
 const custOrgSearch = ref(null);
 const custOrgs = ref([]);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable items
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -174,7 +150,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered list
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
   buildCustomerOrgColumns();
@@ -221,16 +196,6 @@ function buildCustomerOrgColumns() {
 } // buildCustomerOrgColumns
 
 /**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
-
-/**
  * handles click event of the employee table entry
  *
  * @param item - the employee
@@ -238,19 +203,6 @@ function chipColor(id) {
 function handleClick(_, { item }) {
   router.push(`/employee/${item.employeeNumber}`);
 } //handleClick
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
 
 /**
  * Populates all current customer orgs in the search dropdown.
@@ -289,26 +241,14 @@ function refreshDropdownItems() {
   if (custOrgSearch.value) {
     searchCustomerOrgs();
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // remove
 
 /**
  * Filters employees on the data table by the customer org entered by the user.
@@ -328,24 +268,6 @@ function searchCustomerOrgs() {
     });
   }
 } // searchCustomerOrgs
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * Emit new data for tab.value
@@ -370,34 +292,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsCustomerOrgs.vue
+++ b/src/components/reports/ReportsCustomerOrgs.vue
@@ -33,7 +33,9 @@
             @click:clear="custOrgSearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:model-value="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -87,13 +89,13 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 const store = useStore();
 const emitter = inject('emitter');

--- a/src/components/reports/ReportsCustomerOrgs.vue
+++ b/src/components/reports/ReportsCustomerOrgs.vue
@@ -21,7 +21,7 @@
             "
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+        <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-autocomplete
             v-model="custOrgSearch"
             :items="custOrgs"

--- a/src/components/reports/ReportsCustomerOrgs.vue
+++ b/src/components/reports/ReportsCustomerOrgs.vue
@@ -245,7 +245,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsCustomerOrgs.vue
+++ b/src/components/reports/ReportsCustomerOrgs.vue
@@ -262,7 +262,7 @@ function populateCustomerOrgsDropdown() {
       if (org.current) custOrgs.value.push(org.name);
     })
   );
-  custOrgs.value = new Set(custOrgs.value);
+  custOrgs.value = Array.from(new Set(custOrgs.value));
 } // populateCustomerOrgsDropdown
 
 /**

--- a/src/components/reports/ReportsForeignLanguages.vue
+++ b/src/components/reports/ReportsForeignLanguages.vue
@@ -33,7 +33,9 @@
             @click:clear="languageSearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -87,6 +89,7 @@ import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 
 const store = useStore();

--- a/src/components/reports/ReportsForeignLanguages.vue
+++ b/src/components/reports/ReportsForeignLanguages.vue
@@ -33,34 +33,7 @@
             @click:clear="languageSearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            variant="underlined"
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -108,12 +81,14 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
+
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
@@ -147,11 +122,12 @@ const headers = ref([
 const languageSearch = ref(null);
 const languages = ref([]);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable items
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -164,7 +140,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered list
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
   buildLanguagesColumn();
@@ -202,16 +177,6 @@ function buildLanguagesColumn() {
 } // buildLanguagesColumn
 
 /**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
-
-/**
  * handles click event of the employee table entry
  *
  * @param item - the employee
@@ -219,19 +184,6 @@ function chipColor(id) {
 function handleClick(_, { item }) {
   router.push(`/employee/${item.employeeNumber}`);
 } //handleClick
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
 
 /**
  * Populates all languages in the search dropdown.
@@ -270,26 +222,14 @@ function refreshDropdownItems() {
   if (languageSearch.value) {
     searchLanguages();
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // remove
 
 /**
  * Filters employees on the data table by the language entered by the user.
@@ -309,24 +249,6 @@ function searchLanguages() {
     });
   }
 } // searchLanguages
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * Emit new data for tab.value
@@ -351,34 +273,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsForeignLanguages.vue
+++ b/src/components/reports/ReportsForeignLanguages.vue
@@ -227,7 +227,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsForeignLanguages.vue
+++ b/src/components/reports/ReportsForeignLanguages.vue
@@ -243,7 +243,7 @@ function populateLanguagesDropdown() {
       languages.value.push(lang.name);
     })
   );
-  languages.value = new Set(languages.value);
+  languages.value = Array.from(new Set(languages.value));
 } // populateLanguagesDropdown
 
 /**

--- a/src/components/reports/ReportsJobRoles.vue
+++ b/src/components/reports/ReportsJobRoles.vue
@@ -33,7 +33,9 @@
             @click:clear="jobRoleSearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -87,6 +89,7 @@ import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 
 const store = useStore();

--- a/src/components/reports/ReportsJobRoles.vue
+++ b/src/components/reports/ReportsJobRoles.vue
@@ -207,7 +207,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsJobRoles.vue
+++ b/src/components/reports/ReportsJobRoles.vue
@@ -223,7 +223,7 @@ function populateJobRoleDropdown() {
   let employeeJobRoles = _.map(filteredEmployees.value, (employee) => employee.jobRole);
   employeeJobRoles = _.compact(employeeJobRoles);
   _.forEach(employeeJobRoles, (jobRole) => jobRoles.value.push(jobRole));
-  jobRoles.value = new Set(jobRoles.value);
+  jobRoles.value = Array.from(new Set(jobRoles.value));
 } // populateJobRoleDropdown
 
 /**

--- a/src/components/reports/ReportsJobRoles.vue
+++ b/src/components/reports/ReportsJobRoles.vue
@@ -33,34 +33,7 @@
             @click:clear="jobRoleSearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            variant="underlined"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -108,12 +81,14 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
+
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
@@ -147,11 +122,12 @@ const headers = ref([
 const jobRoleSearch = ref(null);
 const jobRoles = ref([]);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable items
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -164,7 +140,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered list
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
   if (localStorage.getItem('requestedFilter')) {
@@ -184,16 +159,6 @@ onMounted(() => {
 // |--------------------------------------------------|
 
 /**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
-
-/**
  * handles click event of the employee table entry
  *
  * @param item - the employee
@@ -201,19 +166,6 @@ function chipColor(id) {
 function handleClick(_, { item }) {
   router.push(`/employee/${item.employeeNumber}`);
 } //handleClick
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
 
 /**
  * Populates all job roles in the search dropdown.
@@ -250,26 +202,14 @@ function refreshDropdownItems() {
   if (jobRoleSearch.value) {
     searchJobRoles();
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // remove
 
 /**
  * Filters employees on the data table by the job role entered by the user.
@@ -289,24 +229,6 @@ function searchJobRoles() {
     });
   }
 } // searchJobRoles
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * Emit new data for tab.value
@@ -331,34 +253,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsSecurityInfo.vue
+++ b/src/components/reports/ReportsSecurityInfo.vue
@@ -307,7 +307,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsSecurityInfo.vue
+++ b/src/components/reports/ReportsSecurityInfo.vue
@@ -318,7 +318,7 @@ function populateBadgeExpirationsDropdown() {
     });
   }
 
-  badgeExpirations.value = new Set(badgeExpirations.value);
+  badgeExpirations.value = Array.from(new Set(badgeExpirations.value));
   // refresh the employees autocomplete list to be those that match the query
   employees.value = populateEmployeesDropdown(filteredEmployees.value);
 } // populateBadgeExpirationsDropdown

--- a/src/components/reports/ReportsSecurityInfo.vue
+++ b/src/components/reports/ReportsSecurityInfo.vue
@@ -45,7 +45,9 @@
             @click:clear="clearanceSearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -106,6 +108,7 @@ import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 
 const store = useStore();

--- a/src/components/reports/ReportsSecurityInfo.vue
+++ b/src/components/reports/ReportsSecurityInfo.vue
@@ -45,34 +45,7 @@
             @click:clear="clearanceSearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            variant="underlined"
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
           <v-checkbox v-model="showInactiveEmployees" label="Show Inactive Users"></v-checkbox>
         </v-col>
@@ -126,13 +99,15 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { add, format, getTodaysDate } from '@/shared/dateUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
+
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
@@ -172,11 +147,12 @@ const badgeExpirations = ref([]);
 const clearanceSearch = ref(null);
 const clearances = ref(['TS/SCI - Full Scope', 'TS/SCI - CI Poly', 'TS/SCI - No Poly', 'Top Secret', 'Secret']);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable items
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -189,7 +165,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered list
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
 
@@ -209,16 +184,6 @@ onMounted(() => {
 // |                     METHODS                      |
 // |                                                  |
 // |--------------------------------------------------|
-
-/**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
 
 /**
  * Returns the expiration dates for all clearances in natural readable format. The sorting key of item.badgeExpiration
@@ -282,19 +247,6 @@ function handleClick(_, { item }) {
 } //handleClick
 
 /**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
-
-/**
  * Populates all job roles in the search dropdown.
  */
 function populateBadgeExpirationsDropdown() {
@@ -350,9 +302,9 @@ function refreshDropdownItems() {
   if (clearanceSearch.value) {
     searchClearances(clearanceSearch.value);
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
@@ -360,19 +312,7 @@ function refreshDropdownItems() {
 } // refreshDropdownItems
 
 /**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // removeTag
-
-/**
- * If there is a desired badge expiration date, will.value calculate what dates fall within the range.
+ * If there is a desired badge expiration date, this will calculate what dates fall within the range.
  *
  * @param requestedDate - the requested search for the badge expiration date
  * @param forDropdown - used to limit the badge expiration dropdown options based on if there were dates found in that range
@@ -441,24 +381,6 @@ function searchClearances(search) {
 } // searchClearances
 
 /**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
-
-/**
  * Emit new data for tab.value
  *
  * @param event the event data containing the table information
@@ -481,34 +403,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsTechnologies.vue
+++ b/src/components/reports/ReportsTechnologies.vue
@@ -261,7 +261,7 @@ function populateTechnologiesDropdown() {
       }
     })
   );
-  technologies.value = new Set(technologies.value);
+  technologies.value = Array.from(new Set(technologies.value));
 } // populateTechnologiesDropdown
 
 /**

--- a/src/components/reports/ReportsTechnologies.vue
+++ b/src/components/reports/ReportsTechnologies.vue
@@ -35,7 +35,9 @@
             @click:clear="technologySearch = null"
           ></v-autocomplete>
         </v-col>
-        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+          <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
+        </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-2 py-0">
           <v-checkbox v-model="showAllTechnologies" hide-details label="Show All Technologies"></v-checkbox>
         </v-col>
@@ -92,6 +94,7 @@ import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
 import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import TagsFilter from '@/components/shared/TagsFilter.vue';
 const store = useStore();
 const emitter = inject('emitter');

--- a/src/components/reports/ReportsTechnologies.vue
+++ b/src/components/reports/ReportsTechnologies.vue
@@ -35,35 +35,7 @@
             @click:clear="technologySearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-2 py-0">
-          <v-autocomplete
-            clearable
-            label="Filter by Tag (click to flip)"
-            v-model="selectedTags"
-            :items="tags"
-            multiple
-            hide-details
-            variant="underlined"
-            item-title="tagName"
-            item-value="id"
-            @update:model-value="refreshDropdownItems()"
-            return-object
-          >
-            <template v-slot:selection="{ item }">
-              <v-chip
-                size="small"
-                closable
-                @click.stop
-                @click="negateTag(item.raw)"
-                @click:close="removeTag(item.raw)"
-                :color="chipColor(item.raw.id)"
-              >
-                {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                {{ item.raw.tagName }}
-              </v-chip>
-            </template>
-          </v-autocomplete>
-        </v-col>
+        <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-2 py-0">
           <v-checkbox v-model="showAllTechnologies" hide-details label="Show All Technologies"></v-checkbox>
         </v-col>
@@ -114,12 +86,13 @@
 
 <script setup>
 import _ from 'lodash';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 import { employeeFilter } from '@/shared/filterUtils';
 import { getActive, getFullName, populateEmployeesDropdown } from './reports-utils';
 import { onMounted, ref, inject, watch } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
 const store = useStore();
 const emitter = inject('emitter');
 const router = useRouter();
@@ -153,12 +126,13 @@ const headers = ref([
 const technologySearch = ref(null);
 const technologies = ref([]);
 const search = ref(null); // query text for datatable search field
-const selectedTags = ref([]);
 const showAllTechnologies = ref(true);
 const showInactiveEmployees = ref(false);
 const sortBy = ref([{ key: 'employeeNumber' }]); // sort datatable items
-const tags = ref([]);
-const tagFlip = ref([]);
+const tagsInfo = ref({
+  selected: [],
+  flipped: []
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -171,7 +145,6 @@ const tagFlip = ref([]);
  */
 onMounted(() => {
   employeesInfo.value = getActive(store.getters.employees); // default to filtered
-  tags.value = store.getters.tags;
   filteredEmployees.value = employeesInfo.value; // one.value is shown
   populateDropdowns(employeesInfo.value);
   buildTechnologiesColumns();
@@ -213,16 +186,6 @@ function buildTechnologiesColumns() {
 } // buildTechnologiesColumns
 
 /**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return tagFlip.value.includes(id) ? 'red' : 'gray';
-} // chipColor
-
-/**
  * handles click event of the employee table entry
  *
  * @param item - the employee
@@ -230,19 +193,6 @@ function chipColor(id) {
 function handleClick(_, { item }) {
   router.push(`/employee/${item.employeeNumber}`);
 } //handleClick
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = tagFlip.value.indexOf(item.id);
-  if (index >= 0) {
-    tagFlip.value.splice(index, 1);
-  } else {
-    tagFlip.value.push(item.id);
-  }
-} // negateTag
 
 /**
  * Populates all technologies in the search dropdown.
@@ -288,26 +238,14 @@ function refreshDropdownItems() {
   if (technologySearch.value) {
     searchTechnologies();
   }
-  if (selectedTags.value.length > 0) {
+  if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee);
+      return selectedTagsHasEmployee(employee.id, tagsInfo);
     });
   }
 
   populateDropdowns(filteredEmployees.value);
 } // refreshDropdownItems
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = selectedTags.value.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    selectedTags.value.splice(selIndex, 1);
-  }
-} // remove
 
 /**
  * Filters employees on the data table by the technology entered by the user.
@@ -331,24 +269,6 @@ function searchTechnologies() {
     });
   }
 } // searchTechnologies
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < selectedTags.value.length; i++) {
-    inTag = selectedTags.value[i].employees.includes(e.id);
-    tagFlipped = tagFlip.value.includes(selectedTags.value[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * Emit new data for tab.value
@@ -387,34 +307,6 @@ watch(showInactiveEmployees, () => {
   employeesInfo.value = store.getters.employees;
   if (!showInactiveEmployees.value) employeesInfo.value = getActive(employeesInfo.value);
   populateDropdowns(employeesInfo.value);
-  refreshDropdownItems();
-});
-
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * watcher.value will be activated when the store is populated again.
- */
-watch(tagFlip, () => {
-  refreshDropdownItems();
-});
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-watch(selectedTags, () => {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < tagFlip.value.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(selectedTags.value, (t) => {
-      if (t.id === tagFlip.value[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      tagFlip.value.splice(i, 1);
-    }
-  }
   refreshDropdownItems();
 });
 </script>

--- a/src/components/reports/ReportsTechnologies.vue
+++ b/src/components/reports/ReportsTechnologies.vue
@@ -243,7 +243,7 @@ function refreshDropdownItems() {
   }
   if (tagsInfo.value.selected.length > 0) {
     filteredEmployees.value = _.filter(filteredEmployees.value, (employee) => {
-      return selectedTagsHasEmployee(employee.id, tagsInfo);
+      return selectedTagsHasEmployee(employee.id, tagsInfo.value);
     });
   }
 

--- a/src/components/reports/ReportsTechnologies.vue
+++ b/src/components/reports/ReportsTechnologies.vue
@@ -35,7 +35,7 @@
             @click:clear="technologySearch = null"
           ></v-autocomplete>
         </v-col>
-        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+        <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-2 py-0">
           <tags-filter v-model="tagsInfo" @update:modelValue="refreshDropdownItems()"></tags-filter>
         </v-col>
         <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-2 py-0">

--- a/src/components/shared/TagsFilter.vue
+++ b/src/components/shared/TagsFilter.vue
@@ -1,39 +1,38 @@
 <template>
-  <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0" :align="isMobile() ? 'center' : ''">
-    <v-autocomplete
-      clearable
-      label="Filter by Tag (click to flip)"
-      v-model="tagsInfo.selected"
-      :items="tags"
-      multiple
-      variant="underlined"
-      item-title="tagName"
-      item-value="id"
-      return-object
-    >
-      <template #chip="{ props, item }">
-        <v-chip
-          size="small"
-          closable
-          @click.stop
-          v-bind="props"
-          @click="negateTag(item.raw)"
-          @click:close="removeTag(item.raw)"
-          :color="chipColor(item.raw.id)"
-        >
-          {{ tagsInfo.flipped.includes(item.raw.id) ? 'NOT ' : '' }}
-          {{ item.raw.tagName }}
-        </v-chip>
-      </template>
-    </v-autocomplete>
-  </v-col>
+  <v-autocomplete
+    :class="props.classProps"
+    clearable
+    label="Filter by Tag (click to flip)"
+    v-model="tagsInfo.selected"
+    :items="store.getters.tags || []"
+    multiple
+    variant="underlined"
+    item-title="tagName"
+    item-value="id"
+    hide-details
+    return-object
+  >
+    <template #chip="{ props, item }">
+      <v-chip
+        size="small"
+        closable
+        @click.stop
+        v-bind="props"
+        @click="negateTag(item.raw)"
+        @click:close="removeTag(item.raw)"
+        :color="chipColor(item.raw.id)"
+      >
+        {{ tagsInfo.flipped.includes(item.raw.id) ? 'NOT ' : '' }}
+        {{ item.raw.tagName }}
+      </v-chip>
+    </template>
+  </v-autocomplete>
 </template>
 
 <script setup>
 import _ from 'lodash';
-import { ref, watch } from 'vue';
+import { watch } from 'vue';
 import { useStore } from 'vuex';
-import { isMobile } from '@/utils/utils';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -55,9 +54,9 @@ const tagsInfo = defineModel({
     );
   }
 });
+const props = defineProps(['classProps']);
 
 const store = useStore();
-const tags = ref(store.getters.tags);
 // |--------------------------------------------------|
 // |                                                  |
 // |                     METHODS                      |

--- a/src/components/shared/TagsFilter.vue
+++ b/src/components/shared/TagsFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+  <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0" :align="isMobile() ? 'center' : ''">
     <v-autocomplete
       clearable
       label="Filter by Tag (click to flip)"
@@ -11,11 +11,12 @@
       item-value="id"
       return-object
     >
-      <template v-slot:selection="{ item }">
+      <template #chip="{ props, item }">
         <v-chip
           size="small"
           closable
           @click.stop
+          v-bind="props"
           @click="negateTag(item.raw)"
           @click:close="removeTag(item.raw)"
           :color="chipColor(item.raw.id)"
@@ -32,6 +33,7 @@
 import _ from 'lodash';
 import { ref, watch } from 'vue';
 import { useStore } from 'vuex';
+import { isMobile } from '@/utils/utils';
 
 // |--------------------------------------------------|
 // |                                                  |

--- a/src/components/shared/TagsFilter.vue
+++ b/src/components/shared/TagsFilter.vue
@@ -1,0 +1,141 @@
+<template>
+  <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+    <v-autocomplete
+      clearable
+      label="Filter by Tag (click to flip)"
+      v-model="tagsInfo.selected"
+      :items="tags"
+      multiple
+      variant="underlined"
+      item-title="tagName"
+      item-value="id"
+      return-object
+    >
+      <template v-slot:selection="{ item }">
+        <v-chip
+          size="small"
+          closable
+          @click.stop
+          @click="negateTag(item.raw)"
+          @click:close="removeTag(item.raw)"
+          :color="chipColor(item.raw.id)"
+        >
+          {{ tagsInfo.flipped.includes(item.raw.id) ? 'NOT ' : '' }}
+          {{ item.raw.tagName }}
+        </v-chip>
+      </template>
+    </v-autocomplete>
+  </v-col>
+</template>
+
+<script setup>
+import _ from 'lodash';
+import { ref, watch } from 'vue';
+import { useStore } from 'vuex';
+import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
+
+// |--------------------------------------------------|
+// |                                                  |
+// |                       SETUP                      |
+// |                                                  |
+// |--------------------------------------------------|
+
+const emit = defineEmits(['update:modelValue']);
+const tagsInfo = defineModel({
+  type: Object,
+  required: true,
+  validator(value) {
+    return (
+      value instanceof Object &&
+      Object.keys(value).includes('selected') &&
+      value['selected'] instanceof Array &&
+      Object.keys(value).includes('flipped') &&
+      value['flipped'] instanceof Array
+    );
+  }
+});
+
+const store = useStore();
+const tags = ref(store.getters.tags);
+// |--------------------------------------------------|
+// |                                                  |
+// |                     METHODS                      |
+// |                                                  |
+// |--------------------------------------------------|
+
+/**
+ * Returns the color that at tag filter chip should be
+ *
+ * @param id ID of the tag item
+ */
+function chipColor(id) {
+  return tagsInfo.value.flipped.includes(id) ? 'red' : 'gray';
+} // chipColor
+
+/**
+ * negates a tag
+ */
+function negateTag(item) {
+  // try to find the id in the flipped array, if it is there then remove it else add it
+  const index = tagsInfo.value.flipped.indexOf(item.id);
+  if (index >= 0) {
+    tagsInfo.value.flipped.splice(index, 1);
+  } else {
+    tagsInfo.value.flipped.push(item.id);
+  }
+} // negateTag
+
+/**
+ * Removes an item from the tag filters's active filters
+ *
+ * @param item - The filter to remove
+ */
+function removeTag(item) {
+  const selIndex = tagsInfo.value.selected.findIndex((t) => t.id === item.id);
+  if (selIndex >= 0) {
+    tagsInfo.value.selected.splice(selIndex, 1);
+  }
+} // removeTag
+
+// |--------------------------------------------------|
+// |                                                  |
+// |                     WATCHERS                     |
+// |                                                  |
+// |--------------------------------------------------|
+
+/**
+ * In the case that the page has been force reloaded (and the store cleared)
+ * this watcher will be activated when the store is populated again.
+ */
+watch(
+  () => tagsInfo.value.flipped,
+  function watchFlipped() {
+    emit('update:modelValue', tagsInfo.value);
+  },
+  { deep: true }
+); // watchflipped;
+
+/**
+ * Remove items from flipped array when they are removed from the selected
+ * tags
+ */
+watch(
+  () => tagsInfo.value.selected,
+  function watchSelected() {
+    let negatedTagRemoved = true;
+    // use normal for loop to have the index
+    for (let i = 0; i < tagsInfo.value.flipped.length; i++) {
+      // try to find the current tag in the selected
+      _.forEach(tagsInfo.value.selected, (t) => {
+        if (t.id === tagsInfo.value.flipped[i]) negatedTagRemoved = false;
+      });
+      // if it isn't there, remove it from flipped too
+      if (negatedTagRemoved) {
+        tagsInfo.value.flipped.splice(i, 1);
+      }
+    }
+    emit('update:modelValue', tagsInfo.value);
+  },
+  { deep: true }
+); // watchSelectedTags
+</script>

--- a/src/components/shared/TagsFilter.vue
+++ b/src/components/shared/TagsFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
+  <v-col cols="6" xl="3" lg="3" md="3" sm="6" class="my-0 py-0">
     <v-autocomplete
       clearable
       label="Filter by Tag (click to flip)"
@@ -32,7 +32,6 @@
 import _ from 'lodash';
 import { ref, watch } from 'vue';
 import { useStore } from 'vuex';
-import { userRoleIsAdmin, userRoleIsManager } from '@/utils/utils';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -110,7 +109,7 @@ function removeTag(item) {
 watch(
   () => tagsInfo.value.flipped,
   function watchFlipped() {
-    emit('update:modelValue', tagsInfo.value);
+    emit('update:modelValue', tagsInfo.value); //required emit to update model
   },
   { deep: true }
 ); // watchflipped;
@@ -134,7 +133,7 @@ watch(
         tagsInfo.value.flipped.splice(i, 1);
       }
     }
-    emit('update:modelValue', tagsInfo.value);
+    emit('update:modelValue', tagsInfo.value); //required emit to update model
   },
   { deep: true }
 ); // watchSelectedTags

--- a/src/shared/employeeUtils.js
+++ b/src/shared/employeeUtils.js
@@ -92,14 +92,10 @@ export function getEmployeeCurrentProjects(employeeId, employees) {
 
 /**
  * helper function: return true if any selected tag has employee listed under it.
+ * NOTE: make sure tagsInfo is the value not the ref!
  *
-<<<<<<< HEAD
- * @param employeeId - the employee's Id
- * @param {Object} tagsInfo - object with selected tags array and flipped tags array
-=======
  * @param employeeId - the employee's ID
  * @param {Object} tagsInfo - object of selected tags array and flipped tags array
->>>>>>> ff1c4da2 (POR-2614-Tag-filtering-in-a-seperate-component-to-be-used-in-multiple-components: refactored myExpensens.vue to use TagsFilter.vue and changed params to selectedTagsHasEmployee methods)
  * @return true if the employee has a tag selected in filters
  */
 export function selectedTagsHasEmployee(employeeId, tagsInfo) {

--- a/src/shared/employeeUtils.js
+++ b/src/shared/employeeUtils.js
@@ -93,7 +93,7 @@ export function getEmployeeCurrentProjects(employeeId, employees) {
 /**
  * helper function: return true if any selected tag has employee listed under it.
  *
- * @param employee - the employee
+ * @param employeeId - the employee's Id
  * @param {Object} tagsInfo - object with selected tags array and flipped tags array
  * @return true if the employee has a tag selected in filters
  */

--- a/src/shared/employeeUtils.js
+++ b/src/shared/employeeUtils.js
@@ -92,10 +92,11 @@ export function getEmployeeCurrentProjects(employeeId, employees) {
 
 /**
  * helper function: return true if any selected tag has employee listed under it.
- * NOTE: make sure tagsInfo is the value not the ref!
  *
  * @param employeeId - the employee's ID
  * @param {Object} tagsInfo - object of selected tags array and flipped tags array
+ * NOTE: make sure tagsInfo is the value object not the ref!
+ *
  * @return true if the employee has a tag selected in filters
  */
 export function selectedTagsHasEmployee(employeeId, tagsInfo) {

--- a/src/shared/employeeUtils.js
+++ b/src/shared/employeeUtils.js
@@ -93,8 +93,13 @@ export function getEmployeeCurrentProjects(employeeId, employees) {
 /**
  * helper function: return true if any selected tag has employee listed under it.
  *
+<<<<<<< HEAD
  * @param employeeId - the employee's Id
  * @param {Object} tagsInfo - object with selected tags array and flipped tags array
+=======
+ * @param employeeId - the employee's ID
+ * @param {Object} tagsInfo - object of selected tags array and flipped tags array
+>>>>>>> ff1c4da2 (POR-2614-Tag-filtering-in-a-seperate-component-to-be-used-in-multiple-components: refactored myExpensens.vue to use TagsFilter.vue and changed params to selectedTagsHasEmployee methods)
  * @return true if the employee has a tag selected in filters
  */
 export function selectedTagsHasEmployee(employeeId, tagsInfo) {

--- a/src/shared/employeeUtils.js
+++ b/src/shared/employeeUtils.js
@@ -90,11 +90,32 @@ export function getEmployeeCurrentProjects(employeeId, employees) {
   return currentProjects;
 }
 
+/**
+ * helper function: return true if any selected tag has employee listed under it.
+ *
+ * @param employee - the employee
+ * @param {Object} tagsInfo - object with selected tags array and flipped tags array
+ * @return true if the employee has a tag selected in filters
+ */
+export function selectedTagsHasEmployee(employeeId, tagsInfo) {
+  const { selected, flipped } = tagsInfo;
+  let inTag, tagFlipped;
+  for (let i = 0; i < selected.length; i++) {
+    inTag = selected[i].employees.includes(employeeId);
+    tagFlipped = flipped.includes(selected[i].id);
+    if (inTag != tagFlipped) {
+      return true;
+    }
+  }
+  return false;
+} // selectedTagsHasEmployee
+
 export default {
   fullName,
   firstAndLastName,
   nicknameAndLastName,
   getEmployeeByID,
   getEmployeeCurrentContracts,
-  getEmployeeCurrentProjects
+  getEmployeeCurrentProjects,
+  selectedTagsHasEmployee
 };

--- a/src/views/Employees.vue
+++ b/src/views/Employees.vue
@@ -82,7 +82,13 @@
                 </v-btn-toggle>
               </v-col>
               <!-- Tags filter -->
-              <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" :align="isMobile() ? 'center' : ''" cols="5" md="5" sm="6">
+              <v-col
+                v-if="userRoleIsAdmin() || userRoleIsManager()"
+                :align="isMobile() ? 'center' : ''"
+                cols="5"
+                md="5"
+                sm="6"
+              >
                 <tags-filter
                   v-model="tagsInfo"
                   @update:modelValue="filterEmployees()"

--- a/src/views/Employees.vue
+++ b/src/views/Employees.vue
@@ -82,37 +82,12 @@
                 </v-btn-toggle>
               </v-col>
               <!-- Tags filter -->
-              <v-col :align="isMobile() ? 'center' : ''" cols="5" md="5" sm="6">
-                <v-autocomplete
-                  v-if="hasAdminPermissions()"
-                  v-model="selectedTags"
-                  class="mt-2 mt-md-4 ml-1 ml-md-4"
-                  variant="underlined"
-                  clearable
-                  label="Filter by Tag (click to flip)"
-                  :items="tags"
-                  multiple
-                  color="gray"
-                  item-title="tagName"
-                  item-value="id"
-                  hide-details
-                  return-object
-                >
-                  <template #chip="{ props, item }">
-                    <v-chip
-                      size="small"
-                      closable
-                      v-bind="props"
-                      :color="chipColor(item.raw.id)"
-                      @click.stop
-                      @click="negateTag(item.raw)"
-                      @click:close="removeTag(item.raw)"
-                    >
-                      {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                      {{ item.raw.tagName }}
-                    </v-chip>
-                  </template>
-                </v-autocomplete>
+              <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" :align="isMobile() ? 'center' : ''" cols="5" md="5" sm="6">
+                <tags-filter
+                  v-model="tagsInfo"
+                  @update:modelValue="filterEmployees()"
+                  classProps="mt-2 mt-md-4 ml-1 ml-md-4"
+                ></tags-filter>
               </v-col>
               <!-- End Tags Filter -->
             </v-row>
@@ -312,7 +287,9 @@ import _ from 'lodash';
 import ConvertEmployeeToCsv from '@/components/employees/csv/ConvertEmployeeToCsv.vue';
 import PowerEditContainer from '@/components/employees/power-edit/PowerEditContainer.vue';
 import TagManager from '@/components/employees/tags/TagManager.vue';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
 import EmployeesSyncModal from '@/components/modals/EmployeesSyncModal.vue';
+import { selectedTagsHasEmployee } from '@/shared/employeeUtils';
 import {
   isEmpty,
   isFullTime,
@@ -337,9 +314,9 @@ import { format } from '../shared/dateUtils';
  * Key for data table, also has implications for custom search
  * of data table
  */
-function dataTableKey() {
-  return { a: this.filter, b: this.selectedTags };
-} // dataTableKey
+// function dataTableKey() {
+//   return { a: this.filter, b: this.selectedTags };
+// } // dataTableKey
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -373,16 +350,6 @@ function clearStatus() {
   this.status['statusMessage'] = null;
   this.status['color'] = null;
 } // clearStatus
-
-/**
- * Returns the color that at tag filter chip should be
- *
- * @param id ID of the tag item
- *
- */
-function chipColor(id) {
-  return this.tagFlip.includes(id) ? 'red' : 'gray';
-} // chipColor
 
 /**
  * Delete an employee and display status.
@@ -442,8 +409,8 @@ function filterEmployees() {
     let fullCheck = this.filter.active.includes('full') && this.isFullTime(employee);
     let partCheck = this.filter.active.includes('part') && this.isPartTime(employee);
     let inactiveCheck = this.filter.active.includes('inactive') && this.isInactive(employee);
-    let tagCheck = this.selectedTagsHasEmployee(employee);
-    return (fullCheck || partCheck || inactiveCheck) && (this.selectedTags.length <= 0 || tagCheck);
+    let tagCheck = selectedTagsHasEmployee(employee.id, this.tagsInfo);
+    return (fullCheck || partCheck || inactiveCheck) && (this.tagsInfo.selected.length <= 0 || tagCheck);
   });
 } // filterEmployees
 
@@ -495,20 +462,6 @@ async function loadBasecampAvatars() {
 }
 
 /**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = this.tagFlip.indexOf(item.id);
-  if (index >= 0) {
-    this.tagFlip.splice(index, 1);
-  } else {
-    this.tagFlip.push(item.id);
-  }
-  this.refreshEmployees();
-} // negateTag
-
-/**
  * Refresh employee data and filters employees.
  */
 async function refreshEmployees() {
@@ -530,18 +483,6 @@ async function refreshEmployees() {
 } // refreshEmployees
 
 /**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = this.selectedTags.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    this.selectedTags.splice(selIndex, 1);
-  }
-} // removeTag
-
-/**
  * open the create employee form
  */
 function renderCreateEmployee() {
@@ -556,24 +497,6 @@ function renderManageTags() {
   this.manageTags = true;
   this.childKey++;
 } // renderManageTags
-
-/**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param e - the employee
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(e) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < this.selectedTags.length; i++) {
-    inTag = this.selectedTags[i].employees.includes(e.id);
-    tagFlipped = this.tagFlip.includes(this.selectedTags[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
 
 /**
  * helper function: return true if given employee is on a tag
@@ -765,34 +688,6 @@ async function watchStoreIsPopulated() {
   if (this.storeIsPopulated) await this.refreshEmployees();
 } // watchStoreIsPopulated
 
-/**
- * In the case that the page has been force reloaded (and the store cleared)
- * this watcher will be activated when the store is populated again.
- */
-function watchTagFlip() {
-  this.filterEmployees();
-} // watchTagFlip
-
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-function watchSelectedTags() {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < this.tagFlip.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(this.selectedTags, (t) => {
-      if (t.id === this.tagFlip[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      this.tagFlip.splice(i, 1);
-    }
-  }
-  this.filterEmployees();
-}
-
 // |--------------------------------------------------|
 // |                                                  |
 // |                      EXPORT                      |
@@ -808,10 +703,11 @@ export default {
     ExportEmployeeData,
     ConvertEmployeeToCsv,
     PowerEditContainer,
-    TagManager
+    TagManager,
+    TagsFilter
   },
   computed: {
-    dataTableKey,
+    // dataTableKey,
     storeIsPopulated
   },
   created,
@@ -910,7 +806,6 @@ export default {
         currentZIP: null
       }, // selected employee
       search: null, // query text for datatable search field
-      selectedTags: [], // tags to include or exclude in filter
       sortBy: [{ key: 'hireDate', order: 'asc' }], // sort datatable items
       status: {
         statusType: undefined,
@@ -920,23 +815,22 @@ export default {
       showExportDataModal: false,
       syncing: false,
       tags: [],
-      tagFlip: [],
-      tagSearchString: '',
+      tagsInfo: {
+        selected: [],
+        flipped: []
+      },
       toggleEmployeesSyncModal: false
     };
   },
   watch: {
     'filter.active': watchFilterActive,
-    storeIsPopulated: watchStoreIsPopulated,
-    tagFlip: watchTagFlip,
-    selectedTags: watchSelectedTags
+    storeIsPopulated: watchStoreIsPopulated
   },
   beforeUnmount,
   methods: {
     changeAvatar,
     clearCreateEmployee,
     clearStatus,
-    chipColor,
     deleteEmployee,
     deleteModelFromTable,
     displayError,
@@ -953,11 +847,9 @@ export default {
     isMobile,
     loadBasecampAvatars,
     monthDayYearFormat,
-    negateTag,
     refreshEmployees,
     renderCreateEmployee,
     renderManageTags,
-    removeTag,
     selectedTagsHasEmployee,
     employeeIsOnTag,
     syncApplications,

--- a/src/views/Employees.vue
+++ b/src/views/Employees.vue
@@ -312,20 +312,6 @@ import { format } from '../shared/dateUtils';
 
 // |--------------------------------------------------|
 // |                                                  |
-// |                     COMPUTED                     |
-// |                                                  |
-// |--------------------------------------------------|
-
-/**
- * Key for data table, also has implications for custom search
- * of data table
- */
-// function dataTableKey() {
-//   return { a: this.filter, b: this.selectedTags };
-// } // dataTableKey
-
-// |--------------------------------------------------|
-// |                                                  |
 // |                     METHODS                      |
 // |                                                  |
 // |--------------------------------------------------|
@@ -713,7 +699,6 @@ export default {
     TagsFilter
   },
   computed: {
-    // dataTableKey,
     storeIsPopulated
   },
   created,

--- a/src/views/MyExpenses.vue
+++ b/src/views/MyExpenses.vue
@@ -57,7 +57,7 @@
                 </v-col>
 
                 <!-- Tags filter -->
-                <tags-filter v-model="tagsInfo" @update:modelValue="refreshExpenses()"></tags-filter>
+                <tags-filter v-model="tagsInfo" @update:modelValue="filterExpenses()"></tags-filter>
                 <!-- End Tags Filter -->
 
                 <!-- Search Bar -->

--- a/src/views/MyExpenses.vue
+++ b/src/views/MyExpenses.vue
@@ -57,7 +57,9 @@
                 </v-col>
 
                 <!-- Tags filter -->
-                <tags-filter v-model="tagsInfo" @update:modelValue="filterExpenses()"></tags-filter>
+                <v-col v-if="userRoleIsAdmin() || userRoleIsManager()" cols="12" md="3">
+                  <tags-filter v-model="tagsInfo" @update:modelValue="filterExpenses()"></tags-filter>
+                </v-col>
                 <!-- End Tags Filter -->
 
                 <!-- Search Bar -->

--- a/src/views/MyExpenses.vue
+++ b/src/views/MyExpenses.vue
@@ -57,37 +57,7 @@
                 </v-col>
 
                 <!-- Tags filter -->
-                <v-col cols="12" md="3">
-                  <v-autocomplete
-                    v-if="userRoleIsAdmin() || userRoleIsManager()"
-                    v-model="selectedTags"
-                    variant="underlined"
-                    clearable
-                    label="Filter by Tag (click to flip)"
-                    :items="tags"
-                    multiple
-                    hide-details
-                    color="gray"
-                    item-title="tagName"
-                    item-value="id"
-                    return-object
-                  >
-                    <template #chip="{ props, item }">
-                      <v-chip
-                        size="small"
-                        closable
-                        v-bind="props"
-                        :color="tagFlip.includes(item.raw.id) ? 'red' : 'gray'"
-                        @click.stop
-                        @click="negateTag(item.raw)"
-                        @click:close="removeTag(item.raw)"
-                      >
-                        {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                        {{ item.raw.tagName }}
-                      </v-chip>
-                    </template>
-                  </v-autocomplete>
-                </v-col>
+                <tags-filter v-model="tagsInfo" @update:modelValue="refreshExpenses()"></tags-filter>
                 <!-- End Tags Filter -->
 
                 <!-- Search Bar -->
@@ -139,37 +109,7 @@
                   />
                 </v-col>
                 <!-- Tags filter -->
-                <v-col cols="6">
-                  <v-autocomplete
-                    v-if="userRoleIsAdmin() || userRoleIsManager()"
-                    v-model="selectedTags"
-                    variant="underlined"
-                    clearable
-                    label="Filter by Tag (click to flip)"
-                    :items="[]"
-                    multiple
-                    hide-details
-                    color="gray"
-                    item-title="tagName"
-                    item-value="id"
-                    return-object
-                  >
-                    <template #chip="{ props, item }">
-                      <v-chip
-                        size="small"
-                        closable
-                        v-bind="props"
-                        :color="tagFlip.includes(item.raw.id) ? 'red' : 'gray'"
-                        @click.stop
-                        @click="negateTag(item.raw)"
-                        @click:close="removeTag(item.raw)"
-                      >
-                        {{ tagFlip.includes(item.raw.id) ? 'NOT ' : '' }}
-                        {{ item.raw.tagName }}
-                      </v-chip>
-                    </template>
-                  </v-autocomplete>
-                </v-col>
+                <tags-filter v-model="tagsInfo" @update:modelValue="filterExpenses()"></tags-filter>
               </v-row>
             </div>
 
@@ -550,6 +490,7 @@ import ConvertExpensesToCsv from '@/components/expenses/ConvertExpensesToCsv.vue
 import DeleteModal from '@/components/modals/DeleteModal.vue';
 import employeeUtils from '@/shared/employeeUtils';
 import ExpenseForm from '@/components/expenses/ExpenseForm.vue';
+import TagsFilter from '@/components/shared/TagsFilter.vue';
 import UnreimburseModal from '@/components/modals/UnreimburseModal.vue';
 import _ from 'lodash';
 import {
@@ -772,24 +713,6 @@ function displayError(err) {
 } // displayError
 
 /**
- * helper function: return true if any selected tag has employee listed under it.
- *
- * @param employeeId - the employee ID
- * @return true if the employee has a tag selected in filters
- */
-function selectedTagsHasEmployee(employeeId) {
-  let inTag, tagFlipped;
-  for (let i = 0; i < this.selectedTags.length; i++) {
-    inTag = this.selectedTags[i].employees.includes(employeeId);
-    tagFlipped = this.tagFlip.includes(this.selectedTags[i].id);
-    if (inTag != tagFlipped) {
-      return true;
-    }
-  }
-  return false;
-} // selectedTagsHasEmployee
-
-/**
  * Filters expenses based on filter selections.
  */
 function filterExpenses() {
@@ -802,9 +725,9 @@ function filterExpenses() {
     });
   }
 
-  if (this.selectedTags?.length > 0) {
+  if (this.tagsInfo.selected?.length > 0) {
     this.filteredExpenses = _.filter(this.filteredExpenses, (expense) => {
-      return this.selectedTagsHasEmployee(expense.employeeId);
+      return employeeUtils.selectedTagsHasEmployee(expense.employeeId, this.tagsInfo);
     });
   }
 
@@ -897,8 +820,6 @@ async function loadMyExpensesData() {
     this.refreshExpenses()
   ]);
 
-  this.tags = this.$store.getters.tags;
-
   // get expense types
   let expenseTypes = this.$store.getters.expenseTypes;
   this.expenseTypes = _.map(expenseTypes, (expenseType) => {
@@ -954,32 +875,6 @@ function onSelect(item) {
   this.expense.edit = true;
   this.expense['cost'] = moneyFilter(item.cost);
 } // onSelect
-
-/**
- * negates a tag
- */
-function negateTag(item) {
-  // try to find the id in the tagFlip array, if it is there then remove it else add it
-  const index = this.tagFlip.indexOf(item.id);
-  if (index >= 0) {
-    this.tagFlip.splice(index, 1);
-  } else {
-    this.tagFlip.push(item.id);
-  }
-  this.refreshExpenses();
-} // negateTag
-
-/**
- * Removes an item from the tag filters's active filters
- *
- * @param item - The filter to remove
- */
-function removeTag(item) {
-  const selIndex = this.selectedTags.findIndex((t) => t.id === item.id);
-  if (selIndex >= 0) {
-    this.selectedTags.splice(selIndex, 1);
-  }
-} // removeTag
 
 /**
  * Refresh expense data and filters expenses.
@@ -1180,26 +1075,6 @@ async function watchStorePopulated() {
   }
 } // watchStorePopulated
 
-/**
- * Remove items from tagFlip array when they are removed from the selected
- * tags
- */
-function watchSelectedTags() {
-  let negatedTagRemoved = true;
-  // use normal for loop to have the index
-  for (let i = 0; i < this.tagFlip.length; i++) {
-    // try to find the current tag in the selectedTags
-    _.forEach(this.selectedTags, (t) => {
-      if (t.id === this.tagFlip[i]) negatedTagRemoved = false;
-    });
-    // if it isn't there, remove it from tagFlip too
-    if (negatedTagRemoved) {
-      this.tagFlip.splice(i, 1);
-    }
-  }
-  this.filterExpenses();
-} // watchSelectedTags
-
 // |--------------------------------------------------|
 // |                                                  |
 // |                      EXPORT                      |
@@ -1212,6 +1087,7 @@ export default {
     ConvertExpensesToCsv,
     DeleteModal,
     ExpenseForm,
+    TagsFilter,
     UnreimburseModal
   },
   directives: { mask },
@@ -1303,7 +1179,6 @@ export default {
         showOnFeed: null
       }, // expense to edit
       search: null, // query text for datatable search field
-      selectedTags: [], // tags to include or exclude in filter
       toSort: [{ key: 'createdAt', order: 'desc' }], // default sort datatable items
       startDateFilter: null,
       startDateFilterMenu: null,
@@ -1312,8 +1187,10 @@ export default {
         statusMessage: '',
         color: ''
       }, // snackbar action status
-      tags: [],
-      tagFlip: [],
+      tagsInfo: {
+        selected: [],
+        flipped: []
+      },
       unreimbursing: false, // activate unreimburse model when value changes
       userInfo: null // user information
     };
@@ -1328,8 +1205,6 @@ export default {
     endDateFilter: watchFilterExpenses,
     startDateFilter: watchFilterExpenses,
     search: watchFilterExpenses,
-    selectedTags: watchSelectedTags,
-    tagFlip: watchFilterExpenses,
     'filter.active': watchFilterExpenses,
     'filter.reimbursed': watchFilterExpenses,
     storeIsPopulated: watchStorePopulated
@@ -1355,7 +1230,6 @@ export default {
     hasRecipient,
     isBetween,
     isEmpty,
-    negateTag,
     userRoleIsAdmin,
     userRoleIsManager,
     isMobile,
@@ -1364,9 +1238,7 @@ export default {
     monthDayYearFormat,
     onSelect,
     parseEventDate,
-    removeTag,
     refreshExpenses,
-    selectedTagsHasEmployee,
     startAction,
     toTopOfForm,
     unreimburseExpense,

--- a/src/views/Reports.vue
+++ b/src/views/Reports.vue
@@ -42,7 +42,7 @@
             <v-menu offset="y">
               <template #activator="{ props }">
                 <v-btn variant="text" theme="dark" class="font-weight-bold" v-bind="props">
-                  {{ currentTab.toUpperCase() }} <v-icon class="pb-1"> mdi-chevron-down </v-icon>
+                  {{ currentTab.title.toUpperCase() }} <v-icon class="pb-1"> mdi-chevron-down </v-icon>
                 </v-btn>
               </template>
               <v-list>


### PR DESCRIPTION
Ticket Link: [POR-2614](https://consultwithcase.atlassian.net/browse/POR-2614)

Made filtering into tags into a seperate component, along with an exported helper function, which is used in All the reports tabs, MyExpenses, Employees, Employees Export, PTO Cashouts, and Reinbursements.

How to test:
1. Reports tabs, go through all the reports tabs and check if filtering by tags and by negating the tags works
2. Same with MyExpenses, Employees, PTO Cashouts, and Reinbursements
3. For Employees Exporting Data, make sure that the exported spreadsheet is the same as if you filtered in Employees
4. If you want to compare with dev as well to make sure it matches

[POR-2614]: https://consultwithcase.atlassian.net/browse/POR-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ