### PR TITLE
POR-2626 allow admins to set contract PoP start date as employee contract year view

### DIFF
--- a/src/components/modals/ContractSettingsModal.vue
+++ b/src/components/modals/ContractSettingsModal.vue
@@ -8,41 +8,28 @@
         </v-card-title>
         <v-card-text>
           <h3>Employee Timesheets Contract View</h3>
-          <div class="px-6 py-2">
-            <div class="d-flex align-center">
-              <span> Employee current project start date: </span>
-              <v-spacer></v-spacer>
-              <div>
-                <v-switch
-                  v-model="model.contractViewEnabled"
-                  color="primary"
-                  density="compact"
-                  :label="model.contractViewEnabled ? 'Enabled' : 'Disabled'"
-                  class="d-inline-block"
-                  hide-details
-                />
-                <v-tooltip activator="parent" location="top">
-                  Displays yearly data based on employee's current project start date
-                </v-tooltip>
-              </div>
-            </div>
-            <div class="d-flex align-center">
-              <span> Contract PoP date: </span>
-              <v-spacer></v-spacer>
-              <div>
-                <v-switch
-                  v-model="model.contractViewEnabled"
-                  color="primary"
-                  density="compact"
-                  :label="model.contractViewEnabled ? 'Enabled' : 'Disabled'"
-                  class="d-inline-block"
-                  hide-details
-                />
-                <v-tooltip activator="parent" location="top">
-                  Displays yearly data based on employee's contract PoP start date
-                </v-tooltip>
-              </div>
-            </div>
+          <div class="pa-6">
+            <v-row v-for="(value, key) of timesheetsContractViewOptions" :key="value">
+              <v-col cols="8" class="d-flex align-center pa-0">
+                {{ value.title }}
+              </v-col>
+              <v-col cols="4" class="pa-0">
+                <div>
+                  <v-switch
+                    color="primary"
+                    density="compact"
+                    :model-value="model.settings?.timesheetsContractViewOption === key"
+                    :label="model.settings?.timesheetsContractViewOption === key ? 'Enabled' : 'Disabled'"
+                    class="d-inline-block"
+                    hide-details
+                    @update:model-value="updateSettings(value, key)"
+                  />
+                  <v-tooltip v-if="value.tooltip" activator="parent" location="top">
+                    {{ value.tooltip }}
+                  </v-tooltip>
+                </div>
+              </v-col>
+            </v-row>
           </div>
         </v-card-text>
         <v-card-actions>
@@ -92,6 +79,13 @@ const store = useStore();
 const loading = ref(false);
 const activate = ref(false);
 const model = ref(_.cloneDeep(props.contract));
+const timesheetsContractViewOptions = ref({
+  0: {
+    title: 'Employee current project start date',
+    tooltip: "Displays yearly data based on employee's current project start date"
+  },
+  1: { title: 'Contract PoP date', tooltip: 'Displays yearly data based on contract PoP start date' }
+});
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -117,8 +111,8 @@ onMounted(() => {
  */
 async function save() {
   loading.value = true;
-  let data = { id: props.contract.id, contractViewEnabled: model.value.contractViewEnabled };
-  await api.updateAttribute(api.CONTRACTS, data, 'contractViewEnabled');
+  let data = { id: props.contract.id, settings: model.value.settings };
+  await api.updateAttribute(api.CONTRACTS, data, 'settings');
   let contracts = store.getters.contracts;
   let i = _.findIndex(contracts, (c) => c.id === model.value.id);
   contracts[i] = _.cloneDeep(model.value);
@@ -126,6 +120,20 @@ async function save() {
   emitter.emit('closed-contract-settings-modal');
   loading.value = false;
 } // save
+
+/**
+ * Updates the settings timesheetsContractViewOption model to the options key.
+ *
+ * @param {Object} value - The timesheetsContractViewOptions value
+ * @param {Number} key - The timesheetsContractViewOptions key
+ */
+function updateSettings(__, key) {
+  _.set(
+    model.value,
+    'settings.timesheetsContractViewOption',
+    model.value.settings?.timesheetsContractViewOption === key ? null : key
+  );
+} // updateSettings
 
 // |--------------------------------------------------|
 // |                                                  |

--- a/src/components/modals/ContractSettingsModal.vue
+++ b/src/components/modals/ContractSettingsModal.vue
@@ -7,28 +7,50 @@
           <span>Settings for {{ contract.primeName }} {{ contract.contractName }}</span>
         </v-card-title>
         <v-card-text>
-          <v-row class="d-flex align-center">
-            <span> Employee Timesheets Contract View: </span>
-            <div>
-              <v-switch
-                v-model="model.contractViewEnabled"
-                color="primary"
-                :label="model.contractViewEnabled ? 'Enabled' : 'Disabled'"
-                class="d-inline-block ml-5"
-                hide-details
-              />
-              <v-tooltip activator="parent" location="top">
-                Displays yearly data based on employee's current project start date
-              </v-tooltip>
+          <h3>Employee Timesheets Contract View</h3>
+          <div class="px-6 py-2">
+            <div class="d-flex align-center">
+              <span> Employee current project start date: </span>
+              <v-spacer></v-spacer>
+              <div>
+                <v-switch
+                  v-model="model.contractViewEnabled"
+                  color="primary"
+                  density="compact"
+                  :label="model.contractViewEnabled ? 'Enabled' : 'Disabled'"
+                  class="d-inline-block"
+                  hide-details
+                />
+                <v-tooltip activator="parent" location="top">
+                  Displays yearly data based on employee's current project start date
+                </v-tooltip>
+              </div>
             </div>
-          </v-row>
+            <div class="d-flex align-center">
+              <span> Contract PoP date: </span>
+              <v-spacer></v-spacer>
+              <div>
+                <v-switch
+                  v-model="model.contractViewEnabled"
+                  color="primary"
+                  density="compact"
+                  :label="model.contractViewEnabled ? 'Enabled' : 'Disabled'"
+                  class="d-inline-block"
+                  hide-details
+                />
+                <v-tooltip activator="parent" location="top">
+                  Displays yearly data based on employee's contract PoP start date
+                </v-tooltip>
+              </div>
+            </div>
+          </div>
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn
             variant="text"
-            @click="
-              emit('closed-contract-settings-modal');
+            @click.native="
+              emitter.emit('closed-contract-settings-modal');
               activate = false;
             "
             :disabled="loading"
@@ -50,10 +72,26 @@
     </v-dialog>
   </div>
 </template>
-<script>
+<script setup>
 import _ from 'lodash';
 import api from '@/shared/api.js';
+import { watch, inject, ref, onMounted } from 'vue';
+import { useStore } from 'vuex';
 import { updateStoreContracts } from '@/utils/storeUtils';
+
+// |--------------------------------------------------|
+// |                                                  |
+// |                      SETUP                       |
+// |                                                  |
+// |--------------------------------------------------|
+
+const props = defineProps(['toggleModal', 'contract']);
+const emitter = inject('emitter');
+const store = useStore();
+
+const loading = ref(false);
+const activate = ref(false);
+const model = ref(_.cloneDeep(props.contract));
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -64,9 +102,9 @@ import { updateStoreContracts } from '@/utils/storeUtils';
 /**
  * Created lifecyle hook
  */
-function created() {
-  if (!this.$store.getters.contracts) this.updateStoreContracts();
-} // created
+onMounted(() => {
+  if (!store.getters.contracts) updateStoreContracts();
+}); // created
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -75,27 +113,18 @@ function created() {
 // |--------------------------------------------------|
 
 /**
- * Emits a message and data if it exists.
- *
- * @param msg - Message to emit
- */
-function emit(msg) {
-  this.emitter.emit(msg);
-} // emit
-
-/**
  * Save contract settings and dispatch updates to store.
  */
 async function save() {
-  this.loading = true;
-  let data = { id: this.contract.id, contractViewEnabled: this.model.contractViewEnabled };
+  loading.value = true;
+  let data = { id: props.contract.id, contractViewEnabled: model.value.contractViewEnabled };
   await api.updateAttribute(api.CONTRACTS, data, 'contractViewEnabled');
-  let contracts = this.$store.getters.contracts;
-  let i = _.findIndex(contracts, (c) => c.id === this.model.id);
-  contracts[i] = _.cloneDeep(this.model);
-  this.$store.dispatch('setContracts', { contracts });
-  this.emit('closed-contract-settings-modal');
-  this.loading = false;
+  let contracts = store.getters.contracts;
+  let i = _.findIndex(contracts, (c) => c.id === model.value.id);
+  contracts[i] = _.cloneDeep(model.value);
+  store.dispatch('setContracts', { contracts });
+  emitter.emit('closed-contract-settings-modal');
+  loading.value = false;
 } // save
 
 // |--------------------------------------------------|
@@ -107,28 +136,11 @@ async function save() {
 /**
  * Watcher for modal toggle
  */
-function watchToggleModal() {
-  this.model = _.cloneDeep(this.contract);
-  if (this.toggleModal) this.activate = true;
-} // watchEmployeesAssignedModal
-
-export default {
-  created,
-  data() {
-    return {
-      loading: false,
-      activate: false,
-      model: _.cloneDeep(this.contract)
-    };
-  },
-  methods: {
-    emit,
-    save,
-    updateStoreContracts
-  },
-  props: ['toggleModal', 'contract'],
-  watch: {
-    toggleModal: watchToggleModal
+watch(
+  () => props.toggleModal,
+  () => {
+    model.value = _.cloneDeep(props.contract);
+    if (props.toggleModal) activate.value = true;
   }
-};
+); // watchEmployeesAssignedModal
 </script>

--- a/src/components/shared/timesheets/TimeData.vue
+++ b/src/components/shared/timesheets/TimeData.vue
@@ -45,6 +45,7 @@ import { computed, inject, ref, onBeforeMount, onBeforeUnmount } from 'vue';
 import { useStore } from 'vuex';
 import { difference, isBefore, now } from '@/shared/dateUtils';
 import { updateStoreContracts } from '@/utils/storeUtils';
+import { getCalendarYearPeriod, getContractYearPeriod } from './time-periods';
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -266,10 +267,12 @@ async function resetData() {
  * @param {Boolean} isYearly - Whether or not the time period is yearly
  */
 async function setDataFromApi(isCalendarYear, isYearly) {
-  let code = isYearly ? (isCalendarYear ? 3 : 4) : 2;
+  let code = !isYearly ? 2 : null;
+  let period = isYearly ? (isCalendarYear ? getCalendarYearPeriod() : getContractYearPeriod(props.employee)) : null;
   let timesheetsData = await api.getTimesheetsData(props.employee.employeeNumber, {
     code,
-    employeeId: props.employee.id
+    employeeId: props.employee.id,
+    ...(period || {})
   });
   if (!hasError(timesheetsData)) {
     timesheets.value = timesheetsData.timesheets;

--- a/src/components/shared/timesheets/TimePeriodHours.vue
+++ b/src/components/shared/timesheets/TimePeriodHours.vue
@@ -52,7 +52,7 @@
           <v-icon size="x-large">mdi-calendar-weekend</v-icon>
         </v-btn>
         <v-tooltip v-if="!timePeriodLoading" activator="parent" location="top">
-          <span>{{ showContractYear() ? 'Contract Year' : 'Coming soon: contract year view' }}</span>
+          <span>{{ showContractYear() ? 'Contract Year' : 'Contract year has not been enabled by an admin' }}</span>
         </v-tooltip>
       </div>
     </v-row>
@@ -264,7 +264,7 @@ const supplementalDataWithPlan = computed(() => {
 function showContractYear() {
   let empCurContract = _.find(props.employee.contracts, (c) => _.find(c.projects, (p) => !p.endDate));
   let contract = _.find(store.getters.contracts, (c) => c.id === empCurContract?.contractId);
-  return contract?.contractViewEnabled;
+  return contract.settings?.timesheetsContractViewOption;
 } // showContractYear
 
 /**

--- a/src/components/shared/timesheets/time-periods.js
+++ b/src/components/shared/timesheets/time-periods.js
@@ -1,0 +1,117 @@
+import _ from 'lodash';
+import store from '../../../../store/index.js';
+import {
+  add,
+  subtract,
+  isBefore,
+  format,
+  getTodaysDate,
+  getYear,
+  setYear,
+  startOf,
+  endOf,
+  DEFAULT_ISOFORMAT
+} from '../../../shared/dateUtils';
+
+/**
+ * Gets the calendar year period.
+ *
+ * @returns Object - The calendar year period for timesheet collection
+ */
+export function getCalendarYearPeriod() {
+  let today = getTodaysDate();
+  let startDate = format(startOf(today, 'year'), null, DEFAULT_ISOFORMAT);
+  let endDate = format(endOf(today, 'year'), null, DEFAULT_ISOFORMAT);
+  let title = format(startDate, null, 'YYYY');
+  return { startDate, endDate, title };
+} // getCalendarYearPeriod
+
+/**
+ * Gets the contract year period based on settings set on the Contracts page. For more info
+ * on the cases, go to modals/ContractSettingsModal.vue and look at timesheetsContractViewOptions.
+ *
+ * @param {Object} employee - The employee to get the contract year period from
+ * @returns Object - The contract year period for timesheet collection
+ */
+export function getContractYearPeriod(employee) {
+  let period = null;
+  let curContract = _.find(employee.contracts, (c) => _.find(c.projects, (p) => !p.endDate));
+  let contract = _.find(store.getters.contracts, (c) => c.id === curContract?.contractId);
+  switch (contract.settings?.timesheetsContractViewOption) {
+    case '0':
+      period = _getContractCurrentProjectPeriod(employee);
+      break;
+    case '1':
+      period = _getContractPoPStartPeriod(contract);
+      break;
+    default:
+  }
+  return period;
+} // getContractYearPeriod
+
+/////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+////////////////////////////// HELPERS //////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Gets the current contract project period for an employee.
+ *
+ * @param {Object} employee - The employee to get the contract year period from
+ * @returns Object - The time period
+ */
+function _getContractCurrentProjectPeriod(employee) {
+  let project = _getCurrentProject(employee);
+  if (!project) return null;
+  return _getYearPeriod(project.startDate);
+} // _getContractCurrentProjectPeriod
+
+/**
+ * Gets the current contract PoP period for an employee.
+ *
+ * @param {Object} contract - The contract object that the employee is currently on
+ * @returns Object - The time period
+ */
+function _getContractPoPStartPeriod(contract) {
+  return _getYearPeriod(contract.popStartDate);
+} // _getContractPoPStartPeriod
+
+/**
+ * Gets a year long period based on the start date and today's date. Today's date will fall between the time period.
+ *
+ * @param {String} sDate - The start date
+ * @returns The year long period
+ */
+function _getYearPeriod(sDate) {
+  let today = getTodaysDate();
+  let currentYear = getYear(today);
+  let startDate = format(sDate, null, DEFAULT_ISOFORMAT);
+  startDate = setYear(startDate, currentYear);
+  if (isBefore(today, startDate, 'day')) startDate = setYear(startDate, currentYear - 1);
+  let endDate = format(add(startDate, 1, 'year'), null, DEFAULT_ISOFORMAT);
+  endDate = format(subtract(endDate, 1, 'day'), null, DEFAULT_ISOFORMAT);
+  let startDateTitle = format(startDate, null, 'MMM D, YYYY');
+  let endDateTitle = format(endDate, null, 'MMM D, YYYY');
+  return { startDate, endDate, title: `${startDateTitle} - ${endDateTitle}` };
+} // _getYearPeriod
+
+/**
+ * Gets the current project that is toggled to show for contract year.
+ *
+ * @param {Object} employee - The employee object
+ * @returns Object - The current project to show
+ */
+function _getCurrentProject(employee) {
+  let currentProject = null;
+  _.forEach(employee.contracts, (c) => {
+    let project = _.find(c.projects, (p) => !p.endDate);
+    if (project) currentProject = _.cloneDeep(project);
+  });
+  return currentProject;
+} // _getCurrentProject
+
+export default {
+  getCalendarYearPeriod,
+  getContractYearPeriod
+};


### PR DESCRIPTION
Ticket link: [https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2626]
Change the Contract settings view to allow admins to set timesheets contract year view based on PoP start date