### PR TITLE
POR 2669 - buttons graying out on expense types

### DIFF
--- a/src/components/modals/DeleteErrorModal.vue
+++ b/src/components/modals/DeleteErrorModal.vue
@@ -54,11 +54,39 @@ function watchToggleDeleteErrorModal() {
 
 // |--------------------------------------------------|
 // |                                                  |
+// |                 LIFECYCLE HOOKS                  |
+// |                                                  |
+// |--------------------------------------------------|
+
+// The watcher above and this emitter kind of do the same thing, but the watcher didn't update when it should've in
+// some cases. To fix this, I used this event instead (fired in ExpenseTypes.vue), but I didn't delete the watcher to
+// avoid breaking anything else.
+
+/**
+ * Created lifecycle hook - sets up event listeners
+ */
+function created() {
+  this.emitter.on('delete-expense-type-error-show', () => {
+    this.activate = true;
+  });
+}
+
+/**
+ * Before Unmount lifecycle hook - removes event listeners
+ */
+function beforeUnmount() {
+  this.emitter.off('delete-expense-type-error-show');
+}
+
+// |--------------------------------------------------|
+// |                                                  |
 // |                      EXPORT                      |
 // |                                                  |
 // |--------------------------------------------------|
 
 export default {
+  created,
+  beforeUnmount,
   data() {
     return {
       activate: false // dialog activator

--- a/src/views/ExpenseTypes.vue
+++ b/src/views/ExpenseTypes.vue
@@ -1142,7 +1142,8 @@ async function validateDelete(item) {
       deleteModel.value['id'] = item.id;
       deleting.value = true;
     } else {
-      invalidDelete.value = true;
+      // tells DeleteErrorModal to appear
+      emitter.emit('delete-expense-type-error-show');
     }
   } catch (err) {
     displayError(err);


### PR DESCRIPTION
Ticket link: [POR 2669](https://consultwithcase.atlassian.net/browse/POR-2669?atlOrigin=eyJpIjoiYzUyZTc2OTRlMjE0NGM4NGI1OWMwODVjY2Q4ZjBlMWMiLCJwIjoiaiJ9)
Fixed the delete/edit buttons graying out when attempting to delete an expense twice