### PR TITLE
POR 2665 - fix budgets graph disappearing when clearing filters

### DIFF
--- a/src/components/charts/custom-charts/BudgetChart.vue
+++ b/src/components/charts/custom-charts/BudgetChart.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="dataReceived">
-    <v-card class="px-10 pt-5 my-7 pointer" v-if="chartData.labels.length > 0">
+    <v-card class="px-10 pt-5 my-7 pointer">
       <bar-chart
         ref="barChart"
         :key="chartKey"


### PR DESCRIPTION
Ticket link: [POR 2665](https://consultwithcase.atlassian.net/browse/POR-2665?atlOrigin=eyJpIjoiNjAwOGNkYjMxODY3NDU1NDg0ZDk3YmM3MzIyMzZlMjUiLCJwIjoiaiJ9)
Fixed budget graph disappearing when clearing filters, requiring a reload to see the graph again.