### PR TITLE
POR-2751-fix-error-handling-on-expenseForm

### DIFF
--- a/src/components/expenses/ExpenseForm.vue
+++ b/src/components/expenses/ExpenseForm.vue
@@ -804,6 +804,7 @@ function clearForm() {
   // don't clear form if there was an error in submitting
   if (this.errorSubmitting) {
     this.errorSubmitting = false; // reset var
+    this.isInactive = false; // enable form
     return;
   }
 

--- a/src/components/utils/FileUpload.vue
+++ b/src/components/utils/FileUpload.vue
@@ -65,7 +65,10 @@ const acceptedFileTypes = computed(() => {
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       '.doc',
-      'image/*',
+      'image/gif', //.gif
+      'image/jpeg', //.jpeg
+      'image/png', //.png
+      'image/bmp', //.bmp
       '.pdf'
     ].join(',');
   }


### PR DESCRIPTION
Made allowed upload types to be the same as the backend to prevent the edge case where image/webp is allowed but errors in the backend.

When an error happens in the form, the form just hangs forever