### PR TITLE
POR-2805-Bug-in-employees-statistics-table: fixed employee stats bug

### DIFF
--- a/src/components/charts/custom-charts/EmployeesTable.vue
+++ b/src/components/charts/custom-charts/EmployeesTable.vue
@@ -68,6 +68,10 @@ onMounted(async () => {
  */
 function clickedRow(_, { item }) {
   localStorage.setItem('requestedFilter', item.employeeNames.join(', '));
+  if (item.value == 0) {
+    console.log('this should display');
+    localStorage.setItem('requestedFilter', 'none');
+  }
   router.push({
     path: '/employees',
     name: 'employees'
@@ -145,7 +149,7 @@ function fillData() {
     { title: 'Total Employees', value: employees.value.length, employeeNames: [] }
   ];
 
-  // remove 'awaiting clerance' parens if value is zero
+  // remove 'awaiting clearance' parens if value is zero
   if (overheadCount == 0) {
     tableContents.value[1].value = `${overheadCount}`;
   }


### PR DESCRIPTION
Ticket Link: [POR-2806](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2805)

Now, when you click on a row that has no employees that match that criteria, the filter on the employees page will be set to 'none' instead of being blank, showing the user that there are no matching results for the row they clicked.