### PR TITLE
POR-2811 - Hide start and end date fields on expense type form when recurring flag is set

### DIFF
--- a/src/components/expense-types/ExpenseTypeForm.vue
+++ b/src/components/expense-types/ExpenseTypeForm.vue
@@ -209,6 +209,7 @@
 
         <!-- Start Date -->
         <v-text-field
+          v-if="!editedExpenseType.recurringFlag"
           variant="underlined"
           v-model="startDateFormatted"
           id="startDate"
@@ -245,6 +246,7 @@
 
         <!-- End Date -->
         <v-text-field
+          v-if="!editedExpenseType.recurringFlag"
           variant="underlined"
           v-model="endDateFormatted"
           id="endDate"


### PR DESCRIPTION
Ticket link: https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2811