### PR TITLE
POR 2794 - Removing clearance dates from being displayed for cleared employees

### DIFF
--- a/src/components/employee-beta/cards/personal/ClearanceCard.vue
+++ b/src/components/employee-beta/cards/personal/ClearanceCard.vue
@@ -4,7 +4,11 @@
       <template v-if="!isEmpty(clearances)" #prependIcon>
         <v-icon size="small" id="personal" color="white"> mdi-shield-account </v-icon>
       </template>
-      <clearance-list v-if="!isEmpty(clearances)" :list="[displayedClearance]"></clearance-list>
+      <clearance-list
+        v-if="!isEmpty(clearances)"
+        :list="[displayedClearance]"
+        :toggleModal="displayedClearance.awaitingClearance"
+      ></clearance-list>
       <p v-if="isEmpty(clearances)" class="text-center mt-6 mx-2">No Clearance Information</p>
       <div v-if="!isEmpty(clearances) && clearances.length != 1" class="text-center">
         <v-card-actions class="d-flex justify-center">

--- a/src/components/employee-beta/lists/ClearanceList.vue
+++ b/src/components/employee-beta/lists/ClearanceList.vue
@@ -16,13 +16,13 @@
           <p v-if="!isEmpty(getBadgeExpirationDate(clearance))" class="gray-text ml-6">
             <b>Expiration: </b>{{ getBadgeExpirationDate(clearance) }}
           </p>
-          <p v-if="!isEmpty(getAdjudicationDates(clearance))" class="gray-text ml-6">
+          <p v-if="toggleModal && !isEmpty(getAdjudicationDates(clearance))" class="gray-text ml-6">
             <b>Adjudication Dates: </b>{{ getAdjudicationDates(clearance) }}
           </p>
-          <p v-if="!isEmpty(getBiDates(clearance))" class="gray-text ml-6">
+          <p v-if="toggleModal && !isEmpty(getBiDates(clearance))" class="gray-text ml-6">
             <b>Bi Dates: </b>{{ getBiDates(clearance) }}
           </p>
-          <p v-if="!isEmpty(getPolyDates(clearance))" class="gray-text ml-6">
+          <p v-if="toggleModal && !isEmpty(getPolyDates(clearance))" class="gray-text ml-6">
             <b>Poly Dates: </b>{{ getPolyDates(clearance) }}
           </p>
         </v-card-text>
@@ -47,6 +47,9 @@ defineProps({
   list: {
     type: Array,
     required: true
+  },
+  toggleModal: {
+    type: Boolean
   }
 });
 

--- a/src/components/employee-beta/modals/ClearanceModal.vue
+++ b/src/components/employee-beta/modals/ClearanceModal.vue
@@ -3,7 +3,7 @@
     <v-card-text>
       <!-- Employee has clearances -->
       <div v-if="!isEmpty(model.clearances)">
-        <clearance-list :list="model.clearances"></clearance-list>
+        <clearance-list :list="model.clearances" :toggleModal="true"></clearance-list>
       </div>
       <!-- Employee does not have clearances -->
       <p v-else class="mt-6 ml-6">No Clearance Information</p>


### PR DESCRIPTION
Ticket Link: [POR 2794](https://consultwithcase.atlassian.net/browse/POR-2794)
Made it so the clearance dates (poly, BI, adjudication) are not displayed for employees who have gotten their clearance approved but it will still display for employees awaiting their clearance. All of the dates should show up when opening up the modal.