### PR TITLE
POR 2772 - Changing the wording for the 'i' on the tech/skills card

### DIFF
--- a/src/components/employee-beta/cards/TechnologiesCard.vue
+++ b/src/components/employee-beta/cards/TechnologiesCard.vue
@@ -7,8 +7,8 @@
             <h3 class="text-white">Tech and Skills</h3>
           </v-col>
           <v-col>
-            <v-tooltip activator="parent" location="right"> Showing current with most years </v-tooltip>
-            <v-icon class="nudge-up" color="white" size="x-small">mdi-information</v-icon>
+            <v-tooltip activator="parent" location="right"> Sorting by current then years of experience </v-tooltip>
+            <v-icon class="nudge-up" color="white" size="15">mdi-information</v-icon>
           </v-col>
         </v-row>
       </template>


### PR DESCRIPTION
Ticket Link: [POR 2772](https://consultwithcase.atlassian.net/browse/POR-2772)
Changed the wording for the 'i' icon on the tech and skills card to be more coherent and made the icon a bit smaller.