### PR TITLE
POR 2768 - Moving the years of experience beside the respective skill rather then below it

### DIFF
--- a/src/components/employee-beta/cards/LanguagesCard.vue
+++ b/src/components/employee-beta/cards/LanguagesCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="infoCard">
     <base-card title="Foreign Languages">
-      <v-card-text class="px-7 pt-5 pb-1 text-black">
+      <v-card-text class="px-2 pt-0 pb-0 text-black">
         <!-- Employee has entered languages-->
         <languages-list v-if="!isEmpty(languages)" :list="filteredList"></languages-list>
         <!-- Employee does not have Language Experience -->

--- a/src/components/employee-beta/cards/TechnologiesCard.vue
+++ b/src/components/employee-beta/cards/TechnologiesCard.vue
@@ -17,7 +17,7 @@
       <template #default>
         <!-- Employee has Technology Experience -->
         <div v-if="!isEmpty(model.technologies)">
-          <technologies-list :list="filteredList"></technologies-list>
+          <technologies-list :list="filteredList" :isModal="false"></technologies-list>
           <div v-if="!isEmpty(model.technologies) && Math.ceil(model.technologies.length / 5) != 1" class="text-center">
             <v-card-actions class="d-flex justify-center">
               <v-btn @click="toggleTechnologiesModal()">Click To See More</v-btn>

--- a/src/components/employee-beta/lists/LanguagesList.vue
+++ b/src/components/employee-beta/lists/LanguagesList.vue
@@ -2,12 +2,16 @@
   <v-list>
     <v-list-item v-for="(language, index) in list" :key="language.name + index">
       <v-row no-gutters class="d-flex align-center">
-        <p class="mt-3">
-          <b>{{ language.name }}</b>
-        </p>
-      </v-row>
-      <v-row no-gutters class="mx-7">
-        <p class="gray-text"><b>Fluency Level: </b>{{ shortenProficiency(language.proficiency) }}</p>
+        <v-col class="d-flex">
+          <v-col>
+            <p>
+              <b>{{ language.name }}</b>
+            </p>
+          </v-col>
+          <v-col>
+            <p class="gray-text"><b>Fluency: </b>{{ shortenProficiency(language.proficiency) }}</p>
+          </v-col>
+        </v-col>
       </v-row>
       <v-row no-gutters class="mx-5">
         <v-divider v-if="index < list.length - 1" />

--- a/src/components/employee-beta/lists/LanguagesList.vue
+++ b/src/components/employee-beta/lists/LanguagesList.vue
@@ -1,7 +1,7 @@
 <template>
   <v-list>
     <v-list-item v-for="(language, index) in list" :key="language.name + index">
-      <v-row no-gutters class="d-flex align-center">
+      <v-row no-gutters>
         <v-col class="d-flex">
           <v-col>
             <p>

--- a/src/components/employee-beta/lists/TechnologiesList.vue
+++ b/src/components/employee-beta/lists/TechnologiesList.vue
@@ -1,29 +1,28 @@
 <template>
   <v-list>
     <v-list-item v-for="(technology, index) in list" :key="technology.name + index">
-      <v-row no-gutters class="fit-content align-center">
-        <v-col class="d-flex">
-          <v-col>
-            <span v-if="technology.current">
-              <v-icon>mdi-check</v-icon>
-              <v-tooltip activator="parent" location="left">Current Skill</v-tooltip>
-            </span>
-          </v-col>
-          <v-col cols="9" style="width: 375px" class="align-left" v-if="isModal && !isMobile()">
-            <!-- there's margin on paragraphs that needs to be removed here -->
-            <p class="title-text ma-0">
-              <b>{{ technology.name }}</b>
-            </p>
-          </v-col>
-          <v-col v-else>
-            <!-- if a skill/tech has a long name then it gets cut off with a ... -->
-            <p class="title-text ma-0" style="width: 15ch; overflow: hidden; text-overflow: ellipsis">
-              <b>{{ technology.name }}</b>
-            </p>
-          </v-col>
-          <v-col>
-            <p class="gray-text">{{ Number(technology.years).toFixed(1) }} years</p>
-          </v-col>
+      <v-row class="fit-content align-center" dense>
+        <v-col cols="auto">
+          <span v-if="technology.current">
+            <v-icon>mdi-check</v-icon>
+            <v-tooltip activator="parent" location="left">Current Skill</v-tooltip>
+          </span>
+          <v-spacer v-else style="min-width: 24px"></v-spacer>
+        </v-col>
+        <v-col v-if="isModal && !isMobile()" class="margin-y ml-2 align-center" cols="9" style="width: 375px">
+          <!-- there's margin on paragraphs that needs to be removed here -->
+          <p class="title-text ma-0">
+            <b>{{ technology.name }}</b>
+          </p>
+        </v-col>
+        <v-col v-else class="margin-y ml-2 d-flex align-center" cols="9">
+          <!-- if a skill/tech has a long name then it gets cut off with a ... -->
+          <p class="title-text ma-0" style="width: 15ch; overflow: hidden; text-overflow: ellipsis">
+            <b>{{ technology.name }}</b>
+          </p>
+        </v-col>
+        <v-col class="d-flex justify-end align-center" cols="1">
+          <p class="gray-text">{{ Number(technology.years).toFixed(1) }} years</p>
         </v-col>
       </v-row>
       <v-row no-gutters class="mx-5">
@@ -61,5 +60,10 @@ defineProps({
 .gray-text {
   color: #828282;
   text-wrap: nowrap;
+}
+
+.margin-y {
+  margin-top: 18px;
+  margin-bottom: 18px;
 }
 </style>

--- a/src/components/employee-beta/lists/TechnologiesList.vue
+++ b/src/components/employee-beta/lists/TechnologiesList.vue
@@ -1,25 +1,29 @@
 <template>
   <v-list>
     <v-list-item v-for="(technology, index) in list" :key="technology.name + index">
-      <v-row no-gutters class="fit-content d-flex align-center">
-        <v-col class="d-flex d-inline">
+      <v-row no-gutters class="fit-content align-center">
+        <v-col class="d-flex">
           <v-col>
             <span v-if="technology.current">
               <v-icon>mdi-check</v-icon>
               <v-tooltip activator="parent" location="left">Current Skill</v-tooltip>
             </span>
           </v-col>
-          <v-col>
+          <v-col cols="9" style="width: 375px" class="align-left" v-if="isModal && !isMobile()">
             <!-- there's margin on paragraphs that needs to be removed here -->
             <p class="title-text ma-0">
               <b>{{ technology.name }}</b>
             </p>
           </v-col>
-        </v-col>
-      </v-row>
-      <v-row no-gutters>
-        <v-col class="ml-15">
-          <p class="gray-text">{{ Number(technology.years).toFixed(1) }} years</p>
+          <v-col v-else>
+            <!-- if a skill/tech has a long name then it gets cut off with a ... -->
+            <p class="title-text ma-0" style="width: 15ch; overflow: hidden; text-overflow: ellipsis">
+              <b>{{ technology.name }}</b>
+            </p>
+          </v-col>
+          <v-col>
+            <p class="gray-text">{{ Number(technology.years).toFixed(1) }} years</p>
+          </v-col>
         </v-col>
       </v-row>
       <v-row no-gutters class="mx-5">
@@ -30,6 +34,7 @@
 </template>
 
 <script setup>
+import { isMobile } from '@/utils/utils';
 // |--------------------------------------------------|
 // |                                                  |
 // |                      SETUP                       |
@@ -40,6 +45,9 @@ defineProps({
   list: {
     type: Array,
     required: true
+  },
+  isModal: {
+    type: Boolean
   }
 });
 </script>

--- a/src/components/employee-beta/modals/TechnologiesModal.vue
+++ b/src/components/employee-beta/modals/TechnologiesModal.vue
@@ -30,7 +30,7 @@
           </fieldset>
         </div>
         <!-- End of Sort Filters -->
-        <technologies-list :list="filteredList"></technologies-list>
+        <technologies-list :list="filteredList" :isModal="true"></technologies-list>
         <div
           v-if="!isEmpty(model.technologies) && Math.ceil(model.technologies.length / ITEMS_PER_PAGE) != 1"
           class="text-center"


### PR DESCRIPTION
Ticket Link: [POR 2768](https://consultwithcase.atlassian.net/browse/POR-2768)
Moved the years of experience that was initially below each of the skills/tech to be beside it now on the tech/skills list. I also did the same thing to the languages list too. It should look fine on mobile view too (Refresh the page once you change to mobile view).