### PR TITLE
POR 2822 - Fixing the 'time on contract' part of the contract modal

### DIFF
--- a/src/components/employee-beta/cards/ContractInfoCard.vue
+++ b/src/components/employee-beta/cards/ContractInfoCard.vue
@@ -173,7 +173,10 @@ function getContractObjectFromId(contractId) {
 function getCurrentAssignment() {
   for (let c in props.model.contracts) {
     for (let p in props.model.contracts[c].projects) {
-      if (!props.model.contracts[c].projects[p].endDate) {
+      if (
+        !props.model.contracts[c].projects[p].endDate ||
+        difference(props.model.contracts[c].projects[p].endDate, getTodaysDate(), 'days') > 0
+      ) {
         currentProjectId.value = props.model.contracts[c].projects[p].projectId;
         currentContractId.value = props.model.contracts[c].contractId;
         return;
@@ -288,7 +291,7 @@ function dateReadable(time) {
  */
 function getProjectLength(project, duration) {
   let length;
-  if (project.endDate) {
+  if (project.endDate && 0 > difference(project.endDate, getTodaysDate(), 'days')) {
     length = difference(project.endDate, project.startDate, duration);
   } else {
     length = difference(getTodaysDate(), project.startDate, duration);


### PR DESCRIPTION
Ticket Link: [POR 2822](https://consultwithcase.atlassian.net/browse/POR-2822)
Fixed the 'time on contract' not displaying the correct number of years/months/days. If a contract had a future end date it used to add that time to the 'time on contract' and also having a future end date caused the portal to think you did not have a current contract. Fixed both these issues so the 'time on contract' should be from start date to present date and it should show your current contract even if it has a future end date.