### PR TITLE
POR 2739 - Making the headers remain permanently at the top of modals

### DIFF
--- a/src/components/employee-beta/cards/PastJobExperienceInfoCard.vue
+++ b/src/components/employee-beta/cards/PastJobExperienceInfoCard.vue
@@ -5,7 +5,7 @@
     </v-card-text>
     <v-card-text v-else>
       <past-experience-list :list="pageList"></past-experience-list>
-      <div v-if="!isEmpty(model.companies) && Math.ceil(model.companies.length / 5) != 1" class="text-center">
+      <div v-if="!isEmpty(model.companies) && Math.ceil(model.companies.length / 4) != 1" class="text-center">
         <v-card-actions class="d-flex justify-center">
           <v-btn @click="toggleJobExpModal()">Click To See More</v-btn>
         </v-card-actions>

--- a/src/components/employee-beta/lists/LanguagesList.vue
+++ b/src/components/employee-beta/lists/LanguagesList.vue
@@ -2,14 +2,14 @@
   <v-list>
     <v-list-item v-for="(language, index) in list" :key="language.name + index">
       <v-row no-gutters class="d-flex align-center">
-        <p class="mt-3">
+        <p>
           <b>{{ language.name }}</b>
         </p>
       </v-row>
       <v-row no-gutters class="mx-7">
         <p class="gray-text"><b>Fluency Level: </b>{{ shortenProficiency(language.proficiency) }}</p>
       </v-row>
-      <v-row no-gutters class="mx-5">
+      <v-row no-gutters class="mx-5 mb-3">
         <v-divider v-if="index < list.length - 1" />
       </v-row>
     </v-list-item>

--- a/src/components/employee-beta/modals/BaseInfoModal.vue
+++ b/src/components/employee-beta/modals/BaseInfoModal.vue
@@ -2,7 +2,10 @@
   <div class="baseInfoModal">
     <v-dialog v-model="toggleModal" max-width="650">
       <v-card>
-        <v-card-title class="d-flex align-center justify-space-between beta_header_style">
+        <v-card-title
+          style="position: sticky; top: 0; z-index: 1"
+          class="d-flex align-center justify-space-between beta_header_style"
+        >
           <h3 class="text-white px-2">{{ title }}</h3>
           <div>
             <!-- Edit Button -->

--- a/src/components/employee-beta/modals/EducationModal.vue
+++ b/src/components/employee-beta/modals/EducationModal.vue
@@ -2,7 +2,10 @@
   <v-dialog v-model="dialog" max-height="500" max-width="900">
     <template v-slot:default>
       <v-card>
-        <v-card-title class="d-flex align-center justify-space-between beta_header_style">
+        <v-card-title
+          style="position: sticky; top: 0; z-index: 1"
+          class="d-flex align-center justify-space-between beta_header_style"
+        >
           <h3>All Education</h3>
           <div>
             <v-btn v-if="isAdmin || isUser" @click="toggleEdit()" density="comfortable" variant="text" icon="">

--- a/src/components/employee-beta/modals/TechnologiesModal.vue
+++ b/src/components/employee-beta/modals/TechnologiesModal.vue
@@ -1,10 +1,10 @@
 <template>
   <base-info-modal title="Technologies and Skills">
-    <v-card-text>
+    <v-card-text class="pt-0">
       <!-- Employee has Technology Experience -->
       <div v-if="!isEmpty(model.technologies)">
         <!--Tech Filters -->
-        <div class="mb-3">
+        <div style="position: sticky; top: 45px; z-index: 1; background-color: white" class="pt-4">
           <fieldset class="filter_border">
             <legend class="legend_style">Sort By</legend>
             <v-col cols="12">
@@ -30,7 +30,7 @@
           </fieldset>
         </div>
         <!-- End of Sort Filters -->
-        <technologies-list :list="filteredList"></technologies-list>
+          <technologies-list :list="filteredList"></technologies-list>
         <div
           v-if="!isEmpty(model.technologies) && Math.ceil(model.technologies.length / ITEMS_PER_PAGE) != 1"
           class="text-center"


### PR DESCRIPTION
Ticket Link: [POR 2739](https://consultwithcase.atlassian.net/browse/POR-2739)
Made the header for scrollable modals permanently remain at the top. Scrollable modals: Tech/skills, foreign languages, clearances and education. Also fixed the past experiences card not displaying the 'click to view more' button. 