### PR TITLE
POR 2731 - making empty displays all same format

### DIFF
--- a/src/components/employee-beta/cards/ContractInfoCard.vue
+++ b/src/components/employee-beta/cards/ContractInfoCard.vue
@@ -13,7 +13,7 @@
         <p><b>No contracts are currently active, to view past assignments click below.</b></p>
       </div>
     </v-card-text>
-    <v-card-text v-else> No contracts to be displayed </v-card-text>
+    <v-card-text style="text-align: center" v-else> No contract Information </v-card-text>
     <v-card-actions>
       <v-btn block @click="open">Click to see more</v-btn>
     </v-card-actions>

--- a/src/components/employee-beta/cards/EducationInfoCard.vue
+++ b/src/components/employee-beta/cards/EducationInfoCard.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="eduTab">
     <base-card title="Education">
-      <v-card-text v-if="isEmpty(showableList)">
-        <p>No Education to display</p>
+      <v-card-text v-if="isEmpty(showableList)" style="text-align: center" class="pt-7">
+        <p>No Education Information</p>
       </v-card-text>
       <v-card-text v-else>
         <education-list :list="showableList"></education-list>

--- a/src/components/employee-beta/cards/HireInfoCard.vue
+++ b/src/components/employee-beta/cards/HireInfoCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-card @click="toggleInfo" elevation="4" width="170px" rounded="1">
+  <v-card elevation="4" width="170px" rounded="1">
     <span style="background-color: red"></span>
     <div class="info-header font-weight-black" style="padding-top: 5px">Hire date</div>
     <div class="info-div">{{ monthDayYearFormat(model.hireDate) || 'No hire date 😫' }}</div>
-    <div v-if="wasIntern && moreInfo" class="info-header font-weight-black">Internship date</div>
-    <div v-if="wasIntern && moreInfo" class="info-div">
+    <div v-if="wasIntern" class="info-header font-weight-black">Internship date</div>
+    <div v-if="wasIntern" class="info-div">
       {{ internshipDate }}
     </div>
-    <div v-if="moreInfo" class="info-header font-weight-black">Time with CASE</div>
-    <div v-if="moreInfo" class="info-div">{{ getYearsWith }} {{ getDaysWith }}</div>
+    <div class="info-header font-weight-black">Time with CASE</div>
+    <div class="info-div">{{ getYearsWith }} {{ getDaysWith }}</div>
   </v-card>
 </template>
 
@@ -24,25 +24,8 @@ import { difference, format, getTodaysDate } from '@/shared/dateUtils';
 // |--------------------------------------------------|
 
 const props = defineProps(['model']);
-const wasIntern = ref(false);
-const internshipDate = ref(null);
-const moreInfo = ref(false);
-
-// |--------------------------------------------------|
-// |                                                  |
-// |                     METHODS                      |
-// |                                                  |
-// |--------------------------------------------------|
-
-/**
- * Expands the card to show more info
- */
-function toggleInfo() {
-  moreInfo.value = !moreInfo.value;
-  //TEMPORARY: dummy data for internship date since there is no internship data fields
-  wasIntern.value = !wasIntern.value;
-  internshipDate.value = 'May 20, 2024';
-} // toggleInfo
+const wasIntern = ref(props.model.employeeRole === 'intern');
+const internshipDate = ref(monthDayYearFormat(props.model.hireDate)); //temp for now
 
 // |--------------------------------------------------|
 // |                                                  |

--- a/src/components/employee-beta/cards/PastJobExperienceInfoCard.vue
+++ b/src/components/employee-beta/cards/PastJobExperienceInfoCard.vue
@@ -1,7 +1,7 @@
 <template>
   <base-card title="Past Experience">
-    <v-card-text v-if="isEmpty(pageList)" class="mt-6" style="font-size: 18px">
-      <p class="ml-6">No past job experience to display</p>
+    <v-card-text v-if="isEmpty(pageList)" class="mt-6" style="text-align: center">
+      <p>No Past Job Experience Information</p>
     </v-card-text>
     <v-card-text v-else>
       <past-experience-list :list="pageList"></past-experience-list>


### PR DESCRIPTION
Ticket Link: [POR 2731](https://consultwithcase.atlassian.net/browse/POR-2731)
Made empty info displays the same for every card and changed hireInfoCard so that it's no longer clickable and just displays all the info. Also internship date is shown for people with the 'intern' employee role.