### PR TITLE
POR-2912: Make submit/cancel button sticky on edit modal

### DIFF
--- a/src/components/employee-beta/forms/EmployeeForm.vue
+++ b/src/components/employee-beta/forms/EmployeeForm.vue
@@ -111,23 +111,25 @@
                   </div>
                 </base-form>
               </v-expansion-panels>
-              <v-card-actions>
-                <v-row class="d-flex align-center">
-                  <!-- Form action buttons -->
-                  <v-col cols="auto">
-                    <v-btn id="employeeCancelBtn" variant="text" class="ma-2" @click="cancel()">Cancel</v-btn>
-                  </v-col>
-                  <v-col cols="auto">
-                    <v-btn id="employeeSubmitBtn" variant="outlined" class="ma-2" color="success" type="submit">
-                      <v-icon class="mr-1">mdi-content-save</v-icon>Submit
-                    </v-btn>
-                  </v-col>
-                  <!-- End form action buttons -->
-                  <v-col cols="auto">
-                    <p v-if="!valid" class="invalid mb-0">Cannot submit, there are invalid fields!</p>
-                  </v-col>
-                </v-row>
-              </v-card-actions>
+              <div class="sticky-actions">
+                <v-card-actions>
+                  <v-row class="d-flex align-center">
+                    <!-- Form action buttons -->
+                    <v-col cols="auto">
+                      <v-btn id="employeeCancelBtn" variant="text" class="ma-2" @click="cancel()">Cancel</v-btn>
+                    </v-col>
+                    <v-col cols="auto">
+                      <v-btn id="employeeSubmitBtn" variant="outlined" class="ma-2" color="success" type="submit">
+                        <v-icon class="mr-1">mdi-content-save</v-icon>Submit
+                      </v-btn>
+                    </v-col>
+                    <!-- End form action buttons -->
+                    <v-col cols="auto">
+                      <p v-if="!valid" class="invalid mb-0">Cannot submit, there are invalid fields!</p>
+                    </v-col>
+                  </v-row>
+                </v-card-actions>
+              </div>
             </v-form>
           </v-col>
         </v-row>
@@ -393,5 +395,11 @@ function isEmpty(value) {
   position: sticky;
   top: 45px;
   z-index: 2;
+}
+.sticky-actions {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  z-index: 1;
 }
 </style>


### PR DESCRIPTION
Ticket link: [POR-2912](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2912)

Cancel and submit buttons now always visible on edit modal

[POR-2912]: https://consultwithcase.atlassian.net/browse/POR-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ