### PR TITLE
POR-2955: certs date fields not automatically clear

### DIFF
--- a/src/components/employee-beta/forms/CertsAndAwardsForm.vue
+++ b/src/components/employee-beta/forms/CertsAndAwardsForm.vue
@@ -43,11 +43,11 @@
               :rules="[...getDateRules()]"
               hint="MM/DD/YYYY format"
               v-mask="'##/##/####'"
-              prepend-inner-icon="mdi-calendar"
+              persistent-hint
               clearable
+              prepend-inner-icon="mdi-calendar"
               autocomplete="off"
               @update:focused="certification.dateReceived = parseEventDate($event)"
-              @focus="certificationIndex = index"
               @keypress="certification.showReceivedMenu = false"
             >
               <v-menu
@@ -341,8 +341,7 @@ function deleteCertification(index) {
  * @return String - The date in YYYY-MM-DD format
  */
 function parseEventDate(event) {
-  const result = format(event.target, 'MM/DD/YYYY', 'YYYY-MM-DD');
-  return result ?? event.target;
+  return format(event.target.value, 'MM/DD/YYYY', 'YYYY-MM-DD');
 } // parseEventDate
 
 /**


### PR DESCRIPTION
Ticket Link: [POR-2955](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2955)

Certification dates no longer automatically clear when the user selects the date field. Only clears if the user backspaces or hits the 'x' icon.

[POR-2955]: https://consultwithcase.atlassian.net/browse/POR-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ