### PR TITLE
POR-2962: fixed mobile view going off the screen

### DIFF
--- a/src/components/employee-beta/forms/PersonalInfoForm.vue
+++ b/src/components/employee-beta/forms/PersonalInfoForm.vue
@@ -211,7 +211,7 @@
               v-model="editedEmployee.personalEmail"
               label="Personal Email"
               :rules="getEmailRules()"
-              style="min-width: 350px"
+              :style="!isMobile() ? 'min-width: 350px' : ''"
             >
               <template #prepend-inner><v-icon>mdi-email</v-icon></template>
               <template #append-inner>


### PR DESCRIPTION
Ticket Link: [POR-2962](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2962)

Fixed the personal information section of the edit modal. Text fields no longer run off the screen in mobile view.

[POR-2962]: https://consultwithcase.atlassian.net/browse/POR-2962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ