### PR TITLE
POR 2973: make hire date only editable when creating an employee

### DIFF
--- a/src/components/employee-beta/forms/EmployeeForm.vue
+++ b/src/components/employee-beta/forms/EmployeeForm.vue
@@ -221,7 +221,7 @@ import api from '@/shared/api';
 import { updateStoreEmployees, updateStoreUser } from '@/utils/storeUtils';
 import { generateUUID, isMobile } from '@/utils/utils';
 import { cloneDeep, find, findIndex, forOwn, isEqual, map, pickBy } from 'lodash';
-import { computed, inject, onBeforeMount, onBeforeUnmount, reactive, ref, watch } from 'vue';
+import { computed, inject, onBeforeMount, onBeforeUnmount, provide, reactive, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useDisplay } from 'vuetify';
 import { useStore } from 'vuex';
@@ -253,6 +253,7 @@ const isUser = inject('isUser');
 // state
 const cardName = ref('');
 const creatingEmployee = ref(false);
+provide('creatingEmployee', creatingEmployee);
 const editing = defineModel();
 const formTabs = ref([]);
 const submitting = ref(false);

--- a/src/components/employee-beta/forms/PersonalInfoForm.vue
+++ b/src/components/employee-beta/forms/PersonalInfoForm.vue
@@ -132,10 +132,9 @@
             ></v-text-field>
           </v-col>
           <!-- hire date -->
-          <v-col>
+          <v-col v-if="creatingEmployee">
             <!-- note that only admins can create an employee, so this is essentially only visible to admins -->
             <v-text-field
-              v-if="creatingEmployee"
               id="employeeHireDateField"
               v-model="hireDateFormatted"
               :rules="getDateRules()"


### PR DESCRIPTION
Ticket link: [POR 2973](https://consultwithcase.atlassian.net/browse/POR-2973)
Make hire date field not visible if user is editing an existing employee.