### PR TITLE
POR 2946: fix spacing when no nickname

### DIFF
--- a/src/components/employee-beta/cards/EmployeeInfoCard.vue
+++ b/src/components/employee-beta/cards/EmployeeInfoCard.vue
@@ -17,7 +17,7 @@
             <h3 class="name-text">{{ employeeName }}</h3>
           </v-col>
           <!-- nickname -->
-          <v-col class="fit-content">
+          <v-col v-if="nickname" class="fit-content">
             <h3 class="nickname-text" :style="`color: ${caseGray}`">{{ nickname }}</h3>
           </v-col>
         </v-row>


### PR DESCRIPTION
Ticket link: [POR 2946](https://consultwithcase.atlassian.net/browse/POR-2946)
Removed the empty line when employee has no nickname