### PR TITLE
POR-2506: Avg hours per day remaining are now orange if between 8 and 9 hours

### DIFF
--- a/src/components/shared/timesheets/TimePeriodDetails.vue
+++ b/src/components/shared/timesheets/TimePeriodDetails.vue
@@ -22,7 +22,7 @@
     <div class="d-flex justify-space-between my-3">
       <div class="mr-2">Remaining Avg/Day</div>
       <div class="dotted-line"></div>
-      <div :class="remainingAverageHoursPerDay > WORK_HOURS_PER_DAY ? 'text-red font-weight-bold' : ''" class="ml-2">
+      <div :class="remainingAverageHoursPerDay > WORK_HOURS_PER_DAY ? avgDayColor : ''" class="ml-2">
         {{ formatNumber(remainingAverageHoursPerDay) }}h
       </div>
     </div>
@@ -152,6 +152,14 @@ onBeforeUnmount(() => {
 // |                    COMPUTED                      |
 // |                                                  |
 // |--------------------------------------------------|
+
+const avgDayColor = computed(() => {
+  if (remainingAverageHoursPerDay.value < 9) {
+    return 'text-orange font-weight-bold';
+  } else {
+    return 'text-red font-weight-bold';
+  }
+});
 
 /**
  * The amount of different days timesheets were entered in the future.


### PR DESCRIPTION
Ticket Link: [POR-2506](https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?label=Interns&selectedIssue=POR-2506)

If the user has an remaining hours per day between 8 and 9, the number will be orange. If the number is greater than or equal to 9, then the number is red

[POR-2506]: https://consultwithcase.atlassian.net/browse/POR-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ