### PR TITLE
POR 2969 - Making the badge expirations not visible when logged out

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -121,7 +121,7 @@
       </v-app-bar>
       <v-main :style="{ padding: getMainPadding() }" class="app-bg-color">
         <v-container fluid grid-list-lg class="px-2 px-md-4">
-          <notification-banners v-if="isLoggedIn() && storeIsPopulated()" />
+          <notification-banners v-if="isLoggedIn() && storeIsPopulated() && !isTimedOut()" />
           <router-view></router-view>
         </v-container>
       </v-main>


### PR DESCRIPTION
Ticket Link: [POR 2969](https://consultwithcase.atlassian.net/browse/POR-2969)
Makes the badge expiration banners not show up when you are logged out (session expired)