### PR TITLE
POR 3008 - Moving the CASE email suffix below the text field as a hint

### DIFF
--- a/src/components/employee-beta/forms/PersonalInfoForm.vue
+++ b/src/components/employee-beta/forms/PersonalInfoForm.vue
@@ -57,7 +57,8 @@
               v-model="emailUsername"
               label="CASE Email *"
               @update:model-value="removeEmailDomain()"
-              :suffix="CASE_EMAIL_DOMAIN"
+              :hint="CASE_EMAIL_DOMAIN"
+              persistent-hint
               :rules="getCaseEmailRules()"
             ></v-text-field>
           </v-col>


### PR DESCRIPTION
Ticket Link: [POR 3008](https://consultwithcase.atlassian.net/browse/POR-3008)
The CASE email domain suffix was covering the text field so it has been moved under it as a persistent hint.