### PR TITLE
POR 2992 - changed icon for badge expiration and certification banners

### DIFF
--- a/src/components/utils/NotificationBanners.vue
+++ b/src/components/utils/NotificationBanners.vue
@@ -121,7 +121,7 @@ function checkBadges() {
               extras: { id: `${user.value.employeeNumber}` }
             },
             closeable: false,
-            status: 'error',
+            status: 'info',
             color: '#f27311',
             message: `Badge ${expire} on ${formattedDate} for clearance: ${clearance.type}`,
             id: randId(),
@@ -154,7 +154,7 @@ function checkCertifications() {
             extras: { id: `${user.value.employeeNumber}` }
           },
           closeable: false,
-          status: 'error',
+          status: 'info',
           color: '#2a49a8',
           message: `Certification ${expire} on ${formattedDate} for certification: ${cert.name}`,
           // below only needed for mark seen button


### PR DESCRIPTION
Ticket Link: [POR 2992](https://consultwithcase.atlassian.net/browse/POR-2992)
Changed badge and cert expiration banner icons from an X to an info icon. The X icon made people think you could click on it to close out the banner.