### PR TITLE
POR 2996 - Phones on their own line and displays their type

### DIFF
--- a/src/components/employee-beta/cards/personal/PersonalInfoCard.vue
+++ b/src/components/employee-beta/cards/personal/PersonalInfoCard.vue
@@ -24,9 +24,7 @@
         </v-row>
         <v-row class="pb-1" v-for="phone in getPhoneNumbers()" :key="phone">
           <v-col class="pa-0">
-            <p class="d-inline pa-0" v-if="!phone.private || isAdmin || isUser">
-              {{ phone.number }}
-            </p>
+            <p class="d-inline pa-0" v-if="!phone.private || isAdmin || isUser">{{ phone.type }}: {{ phone.number }}</p>
           </v-col>
           <v-col cols="auto" class="pa-0">
             <div class="d-inline float-right">


### PR DESCRIPTION
Ticket Link: [POR 2996](https://consultwithcase.atlassian.net/browse/POR-2996)
Redid the story to integrate the previous styling stories that affected this story. Phone numbers should be on their own line and have their type displayed next to it.