### PR TITLE
POR 2989 - save scroll position when navigating through tabs

### DIFF
--- a/src/components/employee-beta/EmployeeInfo.vue
+++ b/src/components/employee-beta/EmployeeInfo.vue
@@ -324,7 +324,9 @@ const useDropDown = computed(() => {
  */
 function selectTab(name) {
   infoTab.value = name;
+  const scrollOffset = document.querySelector('.container').scrollTop;
   router.replace({ hash: '#' + name });
+  window.scroll(scrollOffset);
 } // selectTab
 
 function toggleEdit() {


### PR DESCRIPTION
Ticket Link: [POR 2989](https://consultwithcase.atlassian.net/browse/POR-2989)
Employee profile page no longer resets scroll position to (0,0) when selecting a tab.