### PR TITLE
POR 3076 - improved ui for expense type details

### DIFF
--- a/src/views/ExpenseTypes.vue
+++ b/src/views/ExpenseTypes.vue
@@ -330,23 +330,47 @@
                         <v-row no-gutters>
                           <v-col cols="12" sm="6" md="3" class="flag">
                             <p>Pro-rated:</p>
-                            <v-icon v-if="item.proRated" icon="mdi-check-circle-outline" id="marks" class="mr-1" />
-                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" />
+                            <v-icon
+                              v-if="item.proRated"
+                              icon="mdi-check-circle-outline"
+                              id="marks"
+                              class="mr-1"
+                              color="green"
+                            />
+                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" color="red" />
                           </v-col>
                           <v-col cols="12" sm="6" md="3" class="flag">
                             <p>Overdraft Allowed:</p>
-                            <v-icon v-if="item.odFlag" icon="mdi-check-circle-outline" id="marks" class="mr-1" />
-                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" />
+                            <v-icon
+                              v-if="item.odFlag"
+                              icon="mdi-check-circle-outline"
+                              id="marks"
+                              class="mr-1"
+                              color="green"
+                            />
+                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" color="red" />
                           </v-col>
                           <v-col cols="12" sm="6" md="3" class="flag">
                             <p>Recurring:</p>
-                            <v-icon v-if="item.recurringFlag" icon="mdi-check-circle-outline" id="marks" class="mr-1" />
-                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" />
+                            <v-icon
+                              v-if="item.recurringFlag"
+                              icon="mdi-check-circle-outline"
+                              id="marks"
+                              class="mr-1"
+                              color="green"
+                            />
+                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" color="red" />
                           </v-col>
                           <v-col cols="12" sm="6" md="3" class="flag">
                             <p>Inactive:</p>
-                            <v-icon v-if="item.isInactive" icon="mdi-check-circle-outline" id="marks" class="mr-1" />
-                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" />
+                            <v-icon
+                              v-if="item.isInactive"
+                              icon="mdi-check-circle-outline"
+                              id="marks"
+                              class="mr-1"
+                              color="green"
+                            />
+                            <v-icon v-else icon="mdi-close-circle-outline" id="marks" class="mr-1" color="red" />
                           </v-col>
                         </v-row>
                         <!-- End Flags -->

--- a/src/views/MyExpenses.vue
+++ b/src/views/MyExpenses.vue
@@ -435,16 +435,16 @@
                         <p v-if="!isEmpty(item.category)"><b>Category: </b>{{ item.category }}</p>
                         <div v-if="userRoleIsAdmin() || userRoleIsManager()" class="flagExp">
                           <p>Inactive:</p>
-                          <v-icon v-if="useInactiveStyle(item)" id="marks" class="mr-1 mx-3">
+                          <v-icon v-if="useInactiveStyle(item)" color="green" id="marks" class="mr-1 mx-3">
                             mdi-check-circle-outline
                           </v-icon>
-                          <v-icon v-else class="mr-1 mx-3" id="marks"> mdi-close-circle-outline </v-icon>
+                          <v-icon v-else class="mr-1 mx-3" id="marks" color="red"> mdi-close-circle-outline </v-icon>
                           <br />
                           <p>Show On Feed:</p>
-                          <v-icon v-if="item.showOnFeed" id="marks" class="mr-1 mx-3">
+                          <v-icon v-if="item.showOnFeed" id="marks" class="mr-1 mx-3" color="green">
                             mdi-check-circle-outline
                           </v-icon>
-                          <v-icon v-else class="mr-1 mx-3" id="marks"> mdi-close-circle-outline </v-icon>
+                          <v-icon v-else class="mr-1 mx-3" id="marks" color="red"> mdi-close-circle-outline </v-icon>
                         </div>
                         <div v-if="!isEmpty(item?.rejections?.softRejections)">
                           <b>Revisal Requests:</b>


### PR DESCRIPTION
Ticket Link: [POR 3076](https://consultwithcase.atlassian.net/browse/POR-3076)
Slightly changed UI to make it more evident when one of the flags (inactive, show on feed, etc.) are on or not by using green and red to help differentiate them apart.