### PR TITLE
POR 3074 - improved ui/ux of making an expense type inactive

### DIFF
--- a/src/components/expense-types/ExpenseTypeForm.vue
+++ b/src/components/expense-types/ExpenseTypeForm.vue
@@ -8,17 +8,24 @@
 
     <v-container fluid>
       <v-form ref="expenseTypeForm" v-model="valid" @submit.prevent="valid ? (submitForm = true) : _" lazy-validation>
-        <!-- Budget Name -->
-        <v-text-field
-          variant="underlined"
-          v-model="editedExpenseType.budgetName"
-          id="budgetName"
-          :rules="getRequiredRules()"
-          label="Budget Name"
-          data-vv-name="Budget Name"
-          class="type_form_padding"
-        ></v-text-field>
-
+        <v-row>
+          <v-col>
+            <!-- Budget Name -->
+            <v-text-field
+              variant="underlined"
+              v-model="editedExpenseType.budgetName"
+              id="budgetName"
+              :rules="getRequiredRules()"
+              label="Budget Name"
+              data-vv-name="Budget Name"
+              class="type_form_padding"
+            ></v-text-field>
+          </v-col>
+          <v-col>
+            <!-- Inactive Flag -->
+            <v-checkbox :color="caseRed" label="Mark as Inactive" v-model="editedExpenseType.isInactive"></v-checkbox>
+          </v-col>
+        </v-row>
         <!-- Categories -->
         <v-combobox
           variant="underlined"
@@ -214,8 +221,6 @@
               v-model="editedExpenseType.requiredFlag"
               @update:model-value="toggleRequireReceipt()"
             ></v-checkbox>
-            <!-- Inactive Flag -->
-            <v-checkbox :color="caseRed" label="Mark as Inactive" v-model="editedExpenseType.isInactive"></v-checkbox>
           </v-col>
         </v-row>
 


### PR DESCRIPTION
Ticket Link: [POR 3074](https://consultwithcase.atlassian.net/browse/POR-3074)
I moved the checkbox to the top next to the expense type name (it was mixed in with a bunch of other checkboxes before). Let me know if there are any other suggestions/ideas I could implement instead.