### PR TITLE
POR 3073 - fixed capital letters breaking email logins

### DIFF
--- a/unit-tests/utils/utils.js
+++ b/unit-tests/utils/utils.js
@@ -88,6 +88,10 @@ function getName(type) {
  */
 function login(browser, username = null, password = null) {
   // get defaults for unset vars
+  if (username) {
+    username = username.toLowerCase();
+    //sets the username to lower case to fix capital letters breaking email logins
+  }
   username = username || vars.tester.username;
   password = password || vars.tester.password;
 


### PR DESCRIPTION
Ticket Link: [POR 3073](https://consultwithcase.atlassian.net/browse/POR-3073)
Made all usernames become lower case when entered to prevent capital letters from breaking email logins for some CASE employees.