### PR TITLE
POR-3073 Save employee emails as lowercase

### DIFF
--- a/src/components/employee-beta/forms/PersonalInfoForm.vue
+++ b/src/components/employee-beta/forms/PersonalInfoForm.vue
@@ -874,7 +874,6 @@ function emailValue() {
   if (atIndex !== -1) {
     emailUsername.value = emailUsername.value.substring(0, atIndex).toLowerCase();
   }
-  emailUsername.value = emailUsername.value.toLowerCase();
 } // emailValue
 
 function toggleEdit() {

--- a/src/components/employee-beta/forms/PersonalInfoForm.vue
+++ b/src/components/employee-beta/forms/PersonalInfoForm.vue
@@ -56,7 +56,7 @@
             <v-text-field
               v-model="emailUsername"
               label="CASE Email *"
-              @update:model-value="removeEmailDomain()"
+              @update:model-value="emailValue()"
               :hint="CASE_EMAIL_DOMAIN"
               persistent-hint
               :rules="getCaseEmailRules()"
@@ -868,13 +868,14 @@ async function updateCityBoxes(item) {
  * Removes any text after the '@' symbol on the email username input once the user clicks away.
  * This should help prevent any double domain issues for the CASE email.
  */
-function removeEmailDomain() {
+function emailValue() {
   let atIndex = emailUsername.value.indexOf('@');
 
   if (atIndex !== -1) {
-    emailUsername.value = emailUsername.value.substring(0, atIndex);
+    emailUsername.value = emailUsername.value.substring(0, atIndex).toLowerCase();
   }
-} // removeEmailDomain
+  emailUsername.value = emailUsername.value.toLowerCase();
+} // emailValue
 
 function toggleEdit() {
   emitter.emit('open-dialog');

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -146,7 +146,7 @@ export function getEmailRules() {
 export function getCaseEmailRules() {
   return [
     (v) => !isEmpty(v) || 'Email is required',
-    (v) => /^[a-zA-Z]+$/.test(v) || 'Not a valid @consultwithcase email address'
+    (v) => /^[a-z]+$/.test(v) || 'Not a valid @consultwithcase email address'
   ];
 }
 

--- a/src/shared/validationUtils.js
+++ b/src/shared/validationUtils.js
@@ -146,7 +146,7 @@ export function getEmailRules() {
 export function getCaseEmailRules() {
   return [
     (v) => !isEmpty(v) || 'Email is required',
-    (v) => /^[a-z]+$/.test(v) || 'Not a valid @consultwithcase email address'
+    (v) => /^[a-z\-0-9]+$/.test(v) || 'Can include numbers or lowercase letters'
   ];
 }
 


### PR DESCRIPTION
https://consultwithcase.atlassian.net/browse/POR-3073

The issue is that auth saves the email address as lower case, but when we query DynamoDB it does a case-sensitive match. After a quick look on the internet, it seems like there is no way to make DynamoDB do a query that is not case-sensitive. So we can either:
1. Save all emails as lowercase
2. Query all employee emails, and do our own case-insensitive check

I chose option 1 since it is easier and does not require an additional query every time we check for user info/credentials like option 2 does.