### PR TITLE
POR 3074 - Changing UI/UX of making expense types inactive

### DIFF
--- a/src/components/expense-types/ExpenseTypeForm.vue
+++ b/src/components/expense-types/ExpenseTypeForm.vue
@@ -21,9 +21,15 @@
               class="type_form_padding"
             ></v-text-field>
           </v-col>
-          <v-col>
+          <v-col cols="auto">
             <!-- Inactive Flag -->
-            <v-checkbox :color="caseRed" label="Mark as Inactive" v-model="editedExpenseType.isInactive"></v-checkbox>
+            <v-switch
+              v-model="editedExpenseType.isInactive"
+              :color="caseRed"
+              label="Inactive"
+              hide-details
+              inset
+            ></v-switch>
           </v-col>
         </v-row>
         <!-- Categories -->

--- a/src/components/expense-types/ExpenseTypeForm.vue
+++ b/src/components/expense-types/ExpenseTypeForm.vue
@@ -8,17 +8,24 @@
 
     <v-container fluid>
       <v-form ref="expenseTypeForm" v-model="valid" @submit.prevent="valid ? (submitForm = true) : _" lazy-validation>
-        <!-- Budget Name -->
-        <v-text-field
-          variant="underlined"
-          v-model="editedExpenseType.budgetName"
-          id="budgetName"
-          :rules="getRequiredRules()"
-          label="Budget Name"
-          data-vv-name="Budget Name"
-          class="type_form_padding"
-        ></v-text-field>
-
+        <v-row>
+          <v-col>
+            <!-- Budget Name -->
+            <v-text-field
+              variant="underlined"
+              v-model="editedExpenseType.budgetName"
+              id="budgetName"
+              :rules="getRequiredRules()"
+              label="Budget Name"
+              data-vv-name="Budget Name"
+              class="type_form_padding"
+            ></v-text-field>
+          </v-col>
+          <v-col>
+            <!-- Inactive Flag -->
+            <v-checkbox :color="caseRed" label="Mark as Inactive" v-model="editedExpenseType.isInactive"></v-checkbox>
+          </v-col>
+        </v-row>
         <!-- Categories -->
         <v-combobox
           variant="underlined"
@@ -258,8 +265,6 @@
               v-model="editedExpenseType.requiredFlag"
               @update:model-value="toggleRequireReceipt()"
             ></v-checkbox>
-            <!-- Inactive Flag -->
-            <v-checkbox :color="caseRed" label="Mark as Inactive" v-model="editedExpenseType.isInactive"></v-checkbox>
           </v-col>
         </v-row>
 


### PR DESCRIPTION
Ticket Link: [POR 3074](https://consultwithcase.atlassian.net/browse/POR-3074)
Made it into a switch at the very top of the form so that it's easily visible and accessible. I tried to make it so the switch would be toggled on when the expense type was active but I couldn't figure out a way to do it neatly.