### PR TITLE
POR 3010 - Fixing expense details from being cut off on smaller screens on reimbursements page

### DIFF
--- a/src/components/reimbursements/ReimbursementExpenseDetails.vue
+++ b/src/components/reimbursements/ReimbursementExpenseDetails.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-card v-if="expense" id="reimbursement-expense-details" class="mr-3 my-3 slide-in-blurred-right">
+  <v-card
+    v-if="expense"
+    max-height="300"
+    id="reimbursement-expense-details"
+    class="details mr-3 my-3 slide-in-blurred-right"
+  >
     <v-card-title primary-title class="pb-0 text-h5"> Expense Details </v-card-title>
     <v-card-text>
       <v-container fluid class="px-0 px-md-2 pb-0">
@@ -155,6 +160,12 @@ computed(isMobile);
 .revisal-reason {
   height: 100px;
   max-height: 100px;
+  overflow-y: auto;
+}
+
+.details {
+  height: 300px;
+  max-height: 300px;
   overflow-y: auto;
 }
 

--- a/src/components/reimbursements/UnreimbursedExpenses.vue
+++ b/src/components/reimbursements/UnreimbursedExpenses.vue
@@ -5,7 +5,25 @@
         <!-- Expense Table -->
         <unreimbursed-expenses-table></unreimbursed-expenses-table>
       </v-col>
-      <v-col v-if="!isMobile()" cols="4" class="pr-7 pl-0">
+      <v-col v-if="!isMobile() && height" cols="4" class="followScroll pr-7 pl-0">
+        <!-- Expenses Total -->
+        <reimbursement-totals></reimbursement-totals>
+        <!-- Expense Info -->
+        <reimbursement-expense-details class="mb-3"></reimbursement-expense-details>
+        <!-- Status Alert -->
+        <v-alert
+          v-for="(alert, index) in alerts"
+          :key="index"
+          :type="alert.status"
+          :color="alert.color"
+          density="compact"
+          class="mt-1"
+          id="alert"
+        >
+          {{ alert.message }}
+        </v-alert>
+      </v-col>
+      <v-col v-else-if="!height" cols="4" class="pr-7 pl-0">
         <!-- Expenses Total -->
         <reimbursement-totals></reimbursement-totals>
         <!-- Expense Info -->
@@ -59,6 +77,7 @@ import { ref, onBeforeMount, onBeforeUnmount, computed, inject } from 'vue';
 
 const emitter = inject('emitter');
 const alerts = ref([]); // status alerts
+const height = window.innerHeight > 800;
 
 // |--------------------------------------------------|
 // |                                                  |
@@ -73,7 +92,7 @@ onBeforeMount(async () => {
   emitter.on('reimburseAlert', (theAlerts) => {
     alerts.value = theAlerts;
   });
-}); // created
+}); //created
 
 /**
  * beforeUnmount lifecycle hook.
@@ -90,3 +109,11 @@ onBeforeUnmount(() => {
 
 computed(isMobile);
 </script>
+
+<style>
+.followScroll {
+  position: fixed;
+  left: 67.3%;
+  z-index: 999999 !important;
+}
+</style>

--- a/src/components/reimbursements/UnreimbursedExpenses.vue
+++ b/src/components/reimbursements/UnreimbursedExpenses.vue
@@ -5,29 +5,11 @@
         <!-- Expense Table -->
         <unreimbursed-expenses-table></unreimbursed-expenses-table>
       </v-col>
-      <v-col v-if="!isMobile() && height" cols="4" class="followScroll pr-7 pl-0">
+      <v-col v-if="!isMobile()" cols="4" class="followScroll pr-7 pl-0">
         <!-- Expenses Total -->
         <reimbursement-totals></reimbursement-totals>
         <!-- Expense Info -->
-        <reimbursement-expense-details class="mb-3"></reimbursement-expense-details>
-        <!-- Status Alert -->
-        <v-alert
-          v-for="(alert, index) in alerts"
-          :key="index"
-          :type="alert.status"
-          :color="alert.color"
-          density="compact"
-          class="mt-1"
-          id="alert"
-        >
-          {{ alert.message }}
-        </v-alert>
-      </v-col>
-      <v-col v-else-if="!height" cols="4" class="pr-7 pl-0">
-        <!-- Expenses Total -->
-        <reimbursement-totals></reimbursement-totals>
-        <!-- Expense Info -->
-        <reimbursement-expense-details class="mb-3"></reimbursement-expense-details>
+        <reimbursement-expense-details></reimbursement-expense-details>
         <!-- Status Alert -->
         <v-alert
           v-for="(alert, index) in alerts"
@@ -77,7 +59,6 @@ import { ref, onBeforeMount, onBeforeUnmount, computed, inject } from 'vue';
 
 const emitter = inject('emitter');
 const alerts = ref([]); // status alerts
-const height = window.innerHeight > 800;
 
 // |--------------------------------------------------|
 // |                                                  |

--- a/src/components/reimbursements/UnreimbursedExpenses.vue
+++ b/src/components/reimbursements/UnreimbursedExpenses.vue
@@ -5,7 +5,7 @@
         <!-- Expense Table -->
         <unreimbursed-expenses-table></unreimbursed-expenses-table>
       </v-col>
-      <v-col v-if="!isMobile()" cols="4" class="followScroll pr-7 pl-0">
+      <v-col v-if="!isMobile()" cols="4" class="pr-7 pl-0">
         <!-- Expenses Total -->
         <reimbursement-totals></reimbursement-totals>
         <!-- Expense Info -->
@@ -90,11 +90,3 @@ onBeforeUnmount(() => {
 
 computed(isMobile);
 </script>
-
-<style>
-.followScroll {
-  position: fixed;
-  left: 67.3%;
-  z-index: 999999 !important;
-}
-</style>


### PR DESCRIPTION
Ticket Link: [POR 3010](https://consultwithcase.atlassian.net/browse/POR-3010)
On smaller screens, expense details was getting cut off. Made the details scrollable so that you can see all the information.