### PR TITLE
POR 3128 - Displaying proper location information for place of birth

### DIFF
--- a/src/components/employee-beta/cards/personal/PersonalInfoCard.vue
+++ b/src/components/employee-beta/cards/personal/PersonalInfoCard.vue
@@ -135,8 +135,14 @@ function getPlaceOfBirth() {
     placeOfBirth += `${props.model.city}, `;
   }
 
+  if (!isEmpty(props.model.st)) {
+    placeOfBirth += `${props.model.st}, `;
+  }
+
   if (!isEmpty(props.model.country)) {
-    placeOfBirth += `${props.model.country}, `;
+    if (props.model.country != 'United States') {
+      placeOfBirth += `${props.model.country}, `;
+    }
   }
 
   placeOfBirth = placeOfBirth.slice(0, -2);


### PR DESCRIPTION
Ticket Link: [POR 3128](https://consultwithcase.atlassian.net/browse/POR-3128)
Place of birth used to show 'city, country' but now it shows 'city, state' if the location is in the United States and it shows 'city, country' if the location is outside the United States.