### PR TITLE
POR 3123 - Separation of legacy job hours for calendar year

### DIFF
--- a/src/components/charts/custom-charts/TimesheetsChart.vue
+++ b/src/components/charts/custom-charts/TimesheetsChart.vue
@@ -69,7 +69,7 @@ import _slice from 'lodash/slice';
 // |                                                  |
 // |--------------------------------------------------|
 
-const props = defineProps(['jobcodes', 'nonBillables']);
+const props = defineProps(['jobcodes', 'nonBillables', 'title']);
 const emitter = inject('emitter');
 
 const completed = ref(0);
@@ -140,9 +140,12 @@ async function fillData() {
   let colors = ['#1A237E', '#5C6BC0', '#9FA8DA'];
   let colorsOptions = ['#1A237E', '#5C6BC0', '#9FA8DA'];
   // remove pto jobcodes from chart for yearly data
-  let jobcodes = _pickBy(props.jobcodes, (value, key) => !props.nonBillables?.includes(key));
+  let jobcodes = _pickBy(
+    props.jobcodes,
+    (value, key) => !props.nonBillables?.includes(key) && (value.title == props.title || value.title == null)
+  );
   let jobCodeValues = _map(Object.values(jobcodes), (duration) => {
-    return formatNumber(Number(duration / 60 / 60));
+    return formatNumber(Number((duration.duration ?? duration) / 60 / 60));
   }); // removes decimals if a whole number
 
   let jobCodeValuesSum = _sum(_map(jobCodeValues, (v) => Number(v)));

--- a/src/components/shared/timesheets/AddJobCode.vue
+++ b/src/components/shared/timesheets/AddJobCode.vue
@@ -62,7 +62,7 @@ import { useStore } from 'vuex';
 // |                                                  |
 // |--------------------------------------------------|
 
-const props = defineProps(['employee', 'timeData', 'periodType']);
+const props = defineProps(['employee', 'timeData', 'periodType', 'title']);
 const emitter = inject('emitter');
 const store = useStore();
 
@@ -95,7 +95,10 @@ async function save() {
     // create new legacyJobCodes object in local employee
     let legacyJobCodes = localEmployee.value['legacyJobCodes'] || {};
     if (!legacyJobCodes[props.periodType]) legacyJobCodes[props.periodType] = {};
-    legacyJobCodes[props.periodType][jobCode.value] = Number(duration.value) * 60 * 60;
+    legacyJobCodes[props.periodType][jobCode.value] = {
+      duration: Number(duration.value) * 60 * 60,
+      title: props.title
+    };
     localEmployee.value['legacyJobCodes'] = legacyJobCodes;
     // push new local employee value to the API and store
     let value = { id: props.employee.id, ['legacyJobCodes']: localEmployee.value['legacyJobCodes'] };

--- a/src/components/shared/timesheets/TimePeriodDetails.vue
+++ b/src/components/shared/timesheets/TimePeriodDetails.vue
@@ -106,7 +106,8 @@ const props = defineProps([
   'isYearly',
   'period',
   'supplementalData',
-  'timeData'
+  'timeData',
+  'title'
 ]);
 import _find from 'lodash/find';
 const emitter = inject('emitter');
@@ -221,8 +222,11 @@ const hoursBehindBy = computed(() => {
 const periodHoursCompleted = computed(() => {
   let total = 0;
   _forEach(props.timeData, (duration, jobName) => {
-    if (!props.isYearly || (props.isYearly && !props.supplementalData.nonBillables?.includes(jobName))) {
-      total += duration;
+    if (
+      (duration.title == null || duration.title == props.title) &&
+      (!props.isYearly || (props.isYearly && !props.supplementalData.nonBillables?.includes(jobName)))
+    ) {
+      total += duration.duration ?? duration;
     }
   });
   // convert to hours
@@ -443,7 +447,7 @@ async function check1860OnTrack() {
   let nonBillables = yearlyTimesheetData.supplementalData.nonBillables;
   _forEach(actualTimesheets, (duration, jobName) => {
     if (!nonBillables?.includes(jobName)) {
-      hoursWorked += duration;
+      hoursWorked += duration.duration ?? duration;
     }
   });
   hoursWorked = hoursWorked / 60 / 60; // convert seconds to hours

--- a/src/components/shared/timesheets/TimePeriodHours.vue
+++ b/src/components/shared/timesheets/TimePeriodHours.vue
@@ -107,6 +107,7 @@
           :key="timeData"
           :jobcodes="timeData || {}"
           :nonBillables="isYearly ? supplementalDataWithPlan.nonBillables : null"
+          :title="timesheets[periodIndex].title"
         ></timesheets-chart>
         <!-- End Timesheets Donut Chart -->
       </v-col>
@@ -123,6 +124,7 @@
           :period="timesheets[periodIndex]"
           :supplementalData="supplementalDataWithPlan"
           :timeData="timeData"
+          :title="timesheets[periodIndex]?.title"
         />
       </v-col>
       <!-- End Time Period Details -->
@@ -140,6 +142,7 @@
           :isYearly="isYearly"
           :supplementalData="supplementalDataWithPlan"
           :timeData="timeData"
+          :title="timesheets[periodIndex]?.title"
           :periodType="periodType"
         />
       </v-col>

--- a/src/components/shared/timesheets/TimePeriodJobCodes.vue
+++ b/src/components/shared/timesheets/TimePeriodJobCodes.vue
@@ -27,6 +27,7 @@
       :employee="employee"
       :timeData="timeData"
       :periodType="periodType"
+      :title="title"
       class="ma-2"
     ></add-job-code>
     <div v-if="Object.entries(timeData || {})?.length === 0" class="my-3">No job codes for this time period</div>
@@ -34,7 +35,8 @@
       <div v-for="(duration, jobcode) in timeData" :key="jobcode">
         <div
           v-if="
-            !isYearly || showNonBillables || (!showNonBillables && !supplementalData.nonBillables.includes(jobcode))
+            (duration.title == null || duration.title == title) &&
+            (!isYearly || showNonBillables || (!showNonBillables && !supplementalData.nonBillables.includes(jobcode)))
           "
           :class="isYearly && supplementalData.nonBillables.includes(jobcode) ? 'text-grey' : ''"
           class="d-flex justify-space-between my-3"
@@ -42,7 +44,7 @@
           <div class="mr-3 truncate">{{ jobcode }}</div>
           <div class="dotted-line"></div>
           <div class="d-flex align-center ml-3">
-            <div>{{ formatNumber(duration / 60 / 60) }}h</div>
+            <div>{{ formatNumber((duration.duration ?? duration) / 60 / 60) }}h</div>
             <v-btn
               v-if="showDelete(jobcode)"
               icon
@@ -87,7 +89,15 @@ import { useStore } from 'vuex';
 // |                                                  |
 // |--------------------------------------------------|
 
-const props = defineProps(['employee', 'isCalendarYear', 'isYearly', 'supplementalData', 'timeData', 'periodType']);
+const props = defineProps([
+  'employee',
+  'isCalendarYear',
+  'isYearly',
+  'supplementalData',
+  'timeData',
+  'title',
+  'periodType'
+]);
 const emitter = inject('emitter');
 const store = useStore();
 


### PR DESCRIPTION
Ticket link: [POR 3123](https://consultwithcase.atlassian.net/browse/POR-3123)
In the calendar year tab of the timesheets widget, legacy job codes/hours put into a specific year will only affect that year. 